### PR TITLE
feat: 增加菜单栏统计显示控制设置

### DIFF
--- a/KeyStats/MenuBarController.swift
+++ b/KeyStats/MenuBarController.swift
@@ -136,10 +136,16 @@ class MenuBarController {
         }
 
         appendAppIcon()
-        appendText(" ")
-        appendText(keysText)
-        appendText(" ")
-        appendText(clicksText)
+        
+        if !keysText.isEmpty {
+            appendText(" ")
+            appendText(keysText)
+        }
+        
+        if !clicksText.isEmpty {
+            appendText(" ")
+            appendText(clicksText)
+        }
 
         return result
     }
@@ -222,7 +228,14 @@ class MenuBarStatusView: NSView {
     
     func update(keysText: String, clicksText: String) {
         topLabel.stringValue = keysText
+        topLabel.isHidden = keysText.isEmpty
+        
         bottomLabel.stringValue = clicksText
+        bottomLabel.isHidden = clicksText.isEmpty
+        
+        // 如果只有一个显示，使其居中或者调整布局，这里简化处理，
+        // 依靠 StackView 自动处理隐藏视图的布局
+        
         invalidateIntrinsicContentSize()
         needsLayout = true
     }

--- a/KeyStats/StatsManager.swift
+++ b/KeyStats/StatsManager.swift
@@ -65,6 +65,8 @@ class StatsManager {
     private let userDefaults = UserDefaults.standard
     private let statsKey = "dailyStats"
     private let historyKey = "dailyStatsHistory"
+    private let showKeyPressesKey = "showKeyPressesInMenuBar"
+    private let showMouseClicksKey = "showMouseClicksInMenuBar"
     private let dateFormatter: DateFormatter
     private var history: [String: DailyStats] = [:]
     private var saveTimer: Timer?
@@ -75,6 +77,22 @@ class StatsManager {
     private var isReadyForUpdates = false
     var menuBarUpdateHandler: (() -> Void)?
     var statsUpdateHandler: (() -> Void)?
+    
+    /// 设置：是否在菜单栏显示按键数
+    var showKeyPressesInMenuBar: Bool {
+        didSet {
+            userDefaults.set(showKeyPressesInMenuBar, forKey: showKeyPressesKey)
+            notifyMenuBarUpdate()
+        }
+    }
+    
+    /// 设置：是否在菜单栏显示点击数
+    var showMouseClicksInMenuBar: Bool {
+        didSet {
+            userDefaults.set(showMouseClicksInMenuBar, forKey: showMouseClicksKey)
+            notifyMenuBarUpdate()
+        }
+    }
     
     /// 当前统计数据
     private(set) var currentStats: DailyStats {
@@ -90,6 +108,10 @@ class StatsManager {
     private init() {
         dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        // 加载设置（默认为 true）
+        showKeyPressesInMenuBar = userDefaults.object(forKey: showKeyPressesKey) as? Bool ?? true
+        showMouseClicksInMenuBar = userDefaults.object(forKey: showMouseClicksKey) as? Bool ?? true
 
         // 先初始化 currentStats 为默认值
         let calendar = Calendar.current
@@ -305,8 +327,8 @@ class StatsManager {
 
     /// 获取菜单栏显示的数字部分
     func getMenuBarTextParts() -> (keys: String, clicks: String) {
-        let keys = formatMenuBarNumber(currentStats.keyPresses)
-        let clicks = formatMenuBarNumber(currentStats.totalClicks)
+        let keys = showKeyPressesInMenuBar ? formatMenuBarNumber(currentStats.keyPresses) : ""
+        let clicks = showMouseClicksInMenuBar ? formatMenuBarNumber(currentStats.totalClicks) : ""
         return (keys, clicks)
     }
     

--- a/KeyStats/StatsPopoverViewController.swift
+++ b/KeyStats/StatsPopoverViewController.swift
@@ -31,6 +31,8 @@ class StatsPopoverViewController: NSViewController {
     private var quitButton: NSButton!
     private var permissionButton: NSButton!
     private var launchAtLoginButton: NSButton!
+    private var showKeyPressesButton: NSButton!
+    private var showMouseClicksButton: NSButton!
     
     // MARK: - 生命周期
     
@@ -218,9 +220,24 @@ class StatsPopoverViewController: NSViewController {
         bottomSeparator.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(bottomSeparator)
 
+        // 设置选项
+        showKeyPressesButton = NSButton(checkboxWithTitle: NSLocalizedString("setting.showKeyPresses", comment: ""),
+                                        target: self,
+                                        action: #selector(toggleShowKeyPresses))
+        
+        showMouseClicksButton = NSButton(checkboxWithTitle: NSLocalizedString("setting.showMouseClicks", comment: ""),
+                                         target: self,
+                                         action: #selector(toggleShowMouseClicks))
+
         launchAtLoginButton = NSButton(checkboxWithTitle: NSLocalizedString("button.launchAtLogin", comment: ""),
                                        target: self,
                                        action: #selector(toggleLaunchAtLogin))
+        
+        let settingsStack = NSStackView(views: [showKeyPressesButton, showMouseClicksButton, launchAtLoginButton])
+        settingsStack.orientation = .vertical
+        settingsStack.alignment = .leading
+        settingsStack.spacing = 6
+        settingsStack.translatesAutoresizingMaskIntoConstraints = false
         
         // 按钮容器
         let buttonStack = NSStackView()
@@ -243,7 +260,7 @@ class StatsPopoverViewController: NSViewController {
 
         let footerStack = NSStackView()
         footerStack.orientation = .horizontal
-        footerStack.alignment = .centerY
+        footerStack.alignment = .bottom
         footerStack.spacing = 12
         footerStack.translatesAutoresizingMaskIntoConstraints = false
 
@@ -254,7 +271,7 @@ class StatsPopoverViewController: NSViewController {
         buttonStack.setContentHuggingPriority(.required, for: .horizontal)
         buttonStack.setContentCompressionResistancePriority(.required, for: .horizontal)
 
-        footerStack.addArrangedSubview(launchAtLoginButton)
+        footerStack.addArrangedSubview(settingsStack)
         footerStack.addArrangedSubview(footerSpacer)
         footerStack.addArrangedSubview(buttonStack)
 
@@ -431,6 +448,8 @@ class StatsPopoverViewController: NSViewController {
 
     private func updateLaunchAtLoginState() {
         launchAtLoginButton.state = LaunchAtLoginManager.shared.isEnabled ? .on : .off
+        showKeyPressesButton.state = StatsManager.shared.showKeyPressesInMenuBar ? .on : .off
+        showMouseClicksButton.state = StatsManager.shared.showMouseClicksInMenuBar ? .on : .off
     }
 
     private func focusPrimaryControl() {
@@ -503,6 +522,14 @@ class StatsPopoverViewController: NSViewController {
         NSApplication.shared.terminate(nil)
     }
 
+    @objc private func toggleShowKeyPresses() {
+        StatsManager.shared.showKeyPressesInMenuBar = (showKeyPressesButton.state == .on)
+    }
+    
+    @objc private func toggleShowMouseClicks() {
+        StatsManager.shared.showMouseClicksInMenuBar = (showMouseClicksButton.state == .on)
+    }
+    
     @objc private func toggleLaunchAtLogin() {
         let shouldEnable = launchAtLoginButton.state == .on
         do {

--- a/KeyStats/en.lproj/Localizable.strings
+++ b/KeyStats/en.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 "permission.later" = "Later";
 "button.permission" = "Grant Permission";
 "button.launchAtLogin" = "Open at Login";
+"setting.showKeyPresses" = "Show Key Presses in Menu Bar";
+"setting.showMouseClicks" = "Show Mouse Clicks in Menu Bar";
 "button.ok" = "OK";
 "launchAtLogin.prompt.title" = "Start at Login?";
 "launchAtLogin.prompt.message" = "Would you like KeyStats to open automatically when you log in?";

--- a/KeyStats/zh-Hans.lproj/Localizable.strings
+++ b/KeyStats/zh-Hans.lproj/Localizable.strings
@@ -4,6 +4,8 @@
 "permission.later" = "稍后";
 "button.permission" = "获取权限";
 "button.launchAtLogin" = "开机启动";
+"setting.showKeyPresses" = "在菜单栏显示按键数";
+"setting.showMouseClicks" = "在菜单栏显示点击数";
 "button.ok" = "确定";
 "launchAtLogin.prompt.title" = "是否开机启动？";
 "launchAtLogin.prompt.message" = "是否希望 KeyStats 在登录后自动启动？";


### PR DESCRIPTION
在统计详情面板中增加了两个复选框设置，允许用户独立控制是否在 macOS 菜单栏显示“键盘敲击数”和“鼠标点击数”。

  主要改进内容：

   * 显示控制：支持在菜单栏独立隐藏或显示键盘计数和鼠标点击计数。
   * 布局自适应：菜单栏视图会根据显示内容自动调整宽度，当两项都隐藏时，仅显示应用图标。
   * 数据持久化：用户设置会自动保存，应用重启后依然有效。
   * 本地化支持：已更新 Localizable.strings，完整支持简体中文和英文。
   * 代码维护：未修改任何现有公共方法名，确保与原仓库逻辑的兼容性。