### PR TITLE
feat: 增加统计通知开关与可配置阈值

### DIFF
--- a/KeyStats.xcodeproj/project.pbxproj
+++ b/KeyStats.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		A1000012 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000014 /* SettingsViewController.swift */; };
 		A1000013 /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000015 /* SettingsWindowController.swift */; };
 		A1000014 /* HoverIconButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000016 /* HoverIconButton.swift */; };
+		A1000015 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000017 /* NotificationManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -39,6 +40,7 @@
 		A2000014 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		A2000015 /* SettingsWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowController.swift; sourceTree = "<group>"; };
 		A2000016 /* HoverIconButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverIconButton.swift; sourceTree = "<group>"; };
+		A2000017 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		A3000001 /* KeyStats.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KeyStats.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A3000002 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A3000003 /* KeyStats.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KeyStats.entitlements; sourceTree = "<group>"; };
@@ -74,6 +76,7 @@
 				A2000008 /* MainWindowController.swift */,
 				A2000009 /* MainWindowViewController.swift */,
 				A2000016 /* HoverIconButton.swift */,
+				A2000017 /* NotificationManager.swift */,
 				A2000014 /* SettingsViewController.swift */,
 				A2000015 /* SettingsWindowController.swift */,
 				A2000013 /* LaunchAtLoginManager.swift */,
@@ -177,6 +180,7 @@
 				A1000012 /* SettingsViewController.swift in Sources */,
 				A1000013 /* SettingsWindowController.swift in Sources */,
 				A1000014 /* HoverIconButton.swift in Sources */,
+				A1000015 /* NotificationManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KeyStats/NotificationManager.swift
+++ b/KeyStats/NotificationManager.swift
@@ -1,0 +1,59 @@
+import Foundation
+import UserNotifications
+
+final class NotificationManager {
+    static let shared = NotificationManager()
+
+    enum Metric {
+        case keyPresses
+        case clicks
+    }
+
+    private let center = UNUserNotificationCenter.current()
+
+    private init() {}
+
+    func requestAuthorizationIfNeeded() {
+        center.getNotificationSettings { [weak self] settings in
+            guard let self = self else { return }
+            guard settings.authorizationStatus == .notDetermined else { return }
+            self.center.requestAuthorization(options: [.alert, .sound]) { _, _ in }
+        }
+    }
+
+    func sendThresholdNotification(metric: Metric, count: Int, threshold: Int) {
+        guard threshold > 0 else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = NSLocalizedString("notification.threshold.title", comment: "")
+        content.body = thresholdBody(for: metric, count: count)
+        content.sound = .default
+
+        let identifier = "threshold.\(metricIdentifier(for: metric)).\(count)"
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
+        center.add(request, withCompletionHandler: nil)
+    }
+
+    private func thresholdBody(for metric: Metric, count: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        let formattedCount = formatter.string(from: NSNumber(value: count)) ?? "\(count)"
+        let key: String
+        switch metric {
+        case .keyPresses:
+            key = "notification.threshold.body.keys"
+        case .clicks:
+            key = "notification.threshold.body.clicks"
+        }
+        return String(format: NSLocalizedString(key, comment: ""), formattedCount)
+    }
+
+    private func metricIdentifier(for metric: Metric) -> String {
+        switch metric {
+        case .keyPresses:
+            return "keys"
+        case .clicks:
+            return "clicks"
+        }
+    }
+}

--- a/KeyStats/SettingsWindowController.swift
+++ b/KeyStats/SettingsWindowController.swift
@@ -8,7 +8,7 @@ final class SettingsWindowController: NSWindowController {
         let window = NSWindow(contentViewController: viewController)
         window.styleMask = [.titled, .closable]
         window.title = NSLocalizedString("settings.windowTitle", comment: "")
-        window.setContentSize(NSSize(width: 360, height: 240))
+        window.setContentSize(NSSize(width: 360, height: 320))
         window.isReleasedWhenClosed = false
         window.center()
         super.init(window: window)

--- a/KeyStats/en.lproj/Localizable.strings
+++ b/KeyStats/en.lproj/Localizable.strings
@@ -9,7 +9,15 @@
 "button.back" = "Back";
 "setting.showKeyPresses" = "Show Key Presses in Menu Bar";
 "setting.showMouseClicks" = "Show Mouse Clicks in Menu Bar";
+"setting.notificationsEnabled" = "Enable Statistic Notifications";
+"setting.notifyKeyThreshold" = "Key Press Notification Threshold";
+"setting.notifyClickThreshold" = "Click Notification Threshold";
+"setting.notifyUnit" = "times";
 "button.ok" = "OK";
+
+"notification.threshold.title" = "KeyStats Reminder";
+"notification.threshold.body.keys" = "Key presses reached %@ today.";
+"notification.threshold.body.clicks" = "Clicks reached %@ today.";
 "launchAtLogin.prompt.title" = "Start at Login?";
 "launchAtLogin.prompt.message" = "Would you like KeyStats to open automatically when you log in?";
 "launchAtLogin.prompt.enable" = "Enable";

--- a/KeyStats/zh-Hans.lproj/Localizable.strings
+++ b/KeyStats/zh-Hans.lproj/Localizable.strings
@@ -9,7 +9,15 @@
 "button.back" = "返回";
 "setting.showKeyPresses" = "在菜单栏显示按键数";
 "setting.showMouseClicks" = "在菜单栏显示点击数";
+"setting.notificationsEnabled" = "开启统计通知";
+"setting.notifyKeyThreshold" = "按键通知阈值";
+"setting.notifyClickThreshold" = "点击通知阈值";
+"setting.notifyUnit" = "次";
 "button.ok" = "确定";
+
+"notification.threshold.title" = "统计提醒";
+"notification.threshold.body.keys" = "今日按键数已达到 %@ 次";
+"notification.threshold.body.clicks" = "今日点击数已达到 %@ 次";
 "launchAtLogin.prompt.title" = "是否开机启动？";
 "launchAtLogin.prompt.message" = "是否希望 KeyStats 在登录后自动启动？";
 "launchAtLogin.prompt.enable" = "启用";


### PR DESCRIPTION
## 背景
目前应用只统计键盘/鼠标数据，没有通知机制。新增统计通知功能后，用户可以在达到指定次数（1k、2k、3k…）时收到系统通知，并可在设置中选择是否开启。

## 主要改动
1. **统计通知开关**
   - 新增“开启统计通知”勾选项，默认关闭。
   - 未开启时隐藏阈值设置并完全禁用通知触发。

2. **阈值配置（按键/点击分别设置）**
   - 设置页增加两组阈值输入：按键通知阈值、点击通知阈值
   - 使用“数字输入框 + 步进器”，步进值为 100
   - 阈值为 0 时视为该类通知关闭
   - 每达到阈值的倍数都会提醒（1k、2k、3k…）

3. **通知权限与发送逻辑**
   - 仅在勾选“开启统计通知”时请求通知权限
   - 新增 `NotificationManager` 统一处理权限请求与发送通知
   - 通知文案根据系统语言自动本地化（中英）

4. **统计触发与每日重置**
   - 在按键/点击累积时判断阈值并触发通知
   - 每日重置时同步重置通知基线，避免重复/漏发

## 影响文件
- `KeyStats/StatsManager.swift`
- `KeyStats/SettingsViewController.swift`
- `KeyStats/SettingsWindowController.swift`
- `KeyStats/NotificationManager.swift`（新增）
- `KeyStats/en.lproj/Localizable.strings`
- `KeyStats/zh-Hans.lproj/Localizable.strings`
- `KeyStats.xcodeproj/project.pbxproj`


## 兼容性与隐私
- 只统计数量，不记录内容，符合隐私要求
- 通知权限仅在用户主动开启时请求

<img width="360" height="352" alt="Snipaste_2026-01-12_15-36-53" src="https://github.com/user-attachments/assets/a0664801-f743-45da-8ef7-7488e025ddbe" />
<img width="360" height="352" alt="Snipaste_2026-01-12_15-37-16" src="https://github.com/user-attachments/assets/05757ab2-ac4a-4386-aad8-0dce3e9e391f" />
