### PR TITLE
修复滚轮缩放倍增并减少冗余历史写入（Windows）

### DIFF
--- a/KeyStats.Windows/KeyStats/Services/InputMonitorService.cs
+++ b/KeyStats.Windows/KeyStats/Services/InputMonitorService.cs
@@ -156,7 +156,7 @@ public class InputMonitorService : IDisposable
         // mouseData contains the scroll delta in the high-order word
         var delta = NativeInterop.HiWord((int)mouseData);
         var scrollDistance = Math.Abs(delta) / 120.0 * 10.0; // Normalize and scale
-        MouseScrolled?.Invoke(scrollDistance * 10); // Match macOS scaling factor
+        MouseScrolled?.Invoke(scrollDistance);
     }
 
     public void ResetLastMousePosition()

--- a/KeyStats.Windows/KeyStats/Services/StatsManager.cs
+++ b/KeyStats.Windows/KeyStats/Services/StatsManager.cs
@@ -279,7 +279,6 @@ public class StatsManager : IDisposable
             _saveTimer?.Stop();
             _pendingSave = false;
             SaveStats();
-            SaveHistory();
         };
         _saveTimer.Start();
     }
@@ -667,7 +666,6 @@ public class StatsManager : IDisposable
         _midnightTimer?.Stop();
         _inputRateTimer?.Stop();
         SaveStats();
-        SaveHistory();
         SaveSettings();
     }
 


### PR DESCRIPTION
### Motivation
- 发现鼠标滚轮距离在上报时被额外放大，导致滚动统计偏大并且存在不必要的磁盘写入开销。

### Description
- 在 `KeyStats.Windows/KeyStats/Services/InputMonitorService.cs` 中将 `MouseScrolled?.Invoke(scrollDistance * 10)` 改为 `MouseScrolled?.Invoke(scrollDistance)`，消除多余的缩放。
- 在 `KeyStats.Windows/KeyStats/Services/StatsManager.cs` 中从 `ScheduleSave()` 与 `FlushPendingSave()` 中移除对 `SaveHistory()` 的重复调用，以减少冗余历史文件写入；历史记录仍由 `SaveStats()` 内的 `RecordCurrentStatsToHistory()` 负责一次性记录。
- 仅调整上述逻辑以优化数据上报与持久化频率，未改动数据模型或外部接口。

### Testing
- 未运行任何自动化测试（未执行 `dotnet test` 或其它测试命令）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bb42346bc8328835c52d9f8b72c57)