### PR TITLE
feat(macos): allow configurable time window for dynamic icon color 增加了时间窗口设置，能够平滑用户自定义时间段的活跃程度

### DIFF
--- a/KeyStats/SettingsViewController.swift
+++ b/KeyStats/SettingsViewController.swift
@@ -11,6 +11,8 @@ class SettingsViewController: NSViewController, NSTextFieldDelegate {
     private var dynamicIconColorButton: NSButton!
     private var dynamicIconColorStylePopUp: NSPopUpButton!
     private var dynamicIconColorStyleRow: NSStackView!
+    private var dynamicIconColorWindowField: NSTextField!
+    private var dynamicIconColorWindowRow: NSStackView!
     private var dynamicIconColorHelpButton: NSButton!
     private lazy var dynamicIconColorHelpPopover: NSPopover = makeDynamicIconColorHelpPopover()
     private weak var dynamicIconColorHelpContentView: NSView?
@@ -37,6 +39,15 @@ class SettingsViewController: NSViewController, NSTextFieldDelegate {
         formatter.allowsFloats = false
         formatter.minimum = NSNumber(value: thresholdMinimum)
         formatter.maximum = NSNumber(value: thresholdMaximum)
+        return formatter
+    }()
+    
+    private lazy var windowFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .none
+        formatter.allowsFloats = false
+        formatter.minimum = NSNumber(value: 1)
+        formatter.maximum = NSNumber(value: 3600)
         return formatter
     }()
 
@@ -130,7 +141,25 @@ class SettingsViewController: NSViewController, NSTextFieldDelegate {
         styleRow.translatesAutoresizingMaskIntoConstraints = false
         dynamicIconColorStyleRow = styleRow
 
-        let optionsStack = NSStackView(views: [showKeyPressesButton, showMouseClicksButton, appStatsEnabledButton, launchAtLoginButton, dynamicIconColorRow, styleRow, showThresholdsButton])
+        let windowLabel = NSTextField(labelWithString: NSLocalizedString("settings.dynamicIconColorWindow", comment: ""))
+        windowLabel.font = NSFont.systemFont(ofSize: 13)
+        
+        dynamicIconColorWindowField = NSTextField()
+        dynamicIconColorWindowField.formatter = windowFormatter
+        dynamicIconColorWindowField.target = self
+        dynamicIconColorWindowField.action = #selector(dynamicIconColorWindowChanged)
+        dynamicIconColorWindowField.delegate = self
+        dynamicIconColorWindowField.translatesAutoresizingMaskIntoConstraints = false
+        dynamicIconColorWindowField.widthAnchor.constraint(equalToConstant: 50).isActive = true
+        
+        let windowRow = NSStackView(views: [windowLabel, dynamicIconColorWindowField])
+        windowRow.orientation = .horizontal
+        windowRow.alignment = .centerY
+        windowRow.spacing = 8
+        windowRow.translatesAutoresizingMaskIntoConstraints = false
+        dynamicIconColorWindowRow = windowRow
+
+        let optionsStack = NSStackView(views: [showKeyPressesButton, showMouseClicksButton, appStatsEnabledButton, launchAtLoginButton, dynamicIconColorRow, styleRow, windowRow, showThresholdsButton])
         optionsStack.orientation = .vertical
         optionsStack.alignment = .leading
         optionsStack.spacing = 8
@@ -207,6 +236,9 @@ class SettingsViewController: NSViewController, NSTextFieldDelegate {
         let isEnabled = StatsManager.shared.enableDynamicIconColor
         dynamicIconColorStylePopUp.isEnabled = isEnabled
         dynamicIconColorStyleRow.isHidden = !isEnabled
+        
+        dynamicIconColorWindowRow.isHidden = !isEnabled
+        dynamicIconColorWindowField.doubleValue = StatsManager.shared.dynamicIconColorWindow
     }
 
     private func makeDynamicIconColorHelpPopover() -> NSPopover {
@@ -450,6 +482,11 @@ class SettingsViewController: NSViewController, NSTextFieldDelegate {
         applyThreshold(clickThresholdStepper.integerValue, for: .click)
     }
 
+    @objc private func dynamicIconColorWindowChanged(_ sender: NSTextField) {
+        let value = windowFormatter.number(from: sender.stringValue)?.doubleValue ?? 3.0
+        StatsManager.shared.dynamicIconColorWindow = value
+    }
+
     @objc private func thresholdFieldEdited(_ sender: NSTextField) {
         let value = thresholdFormatter.number(from: sender.stringValue)?.intValue ?? 0
         if sender == keyPressThresholdField {
@@ -461,7 +498,11 @@ class SettingsViewController: NSViewController, NSTextFieldDelegate {
 
     func controlTextDidEndEditing(_ notification: Notification) {
         guard let field = notification.object as? NSTextField else { return }
-        thresholdFieldEdited(field)
+        if field == dynamicIconColorWindowField {
+            dynamicIconColorWindowChanged(field)
+        } else {
+            thresholdFieldEdited(field)
+        }
     }
 
     // MARK: - Actions

--- a/KeyStats/en.lproj/Localizable.strings
+++ b/KeyStats/en.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "settings.dynamicIconColorStyle" = "Display When Enabled";
 "settings.dynamicIconColorStyle.icon" = "Tint Icon";
 "settings.dynamicIconColorStyle.dot" = "Status Dot";
+"settings.dynamicIconColorWindow" = "Time Window (sec)";
 "settings.dynamicIconColorHelp.title" = "Dynamic Color Guide";
 "settings.dynamicIconColorHelp.body" = "Colors are calculated from recent input rate and shown in the menu bar.\n\nAPM (events per minute) ranges:\n• < 80: no tint (default)\n• 80–160: light green → green\n• 160–240: yellow → red\n• ≥ 240: red";
 "settings.windowTitle" = "KeyStats Settings";

--- a/KeyStats/zh-Hans.lproj/Localizable.strings
+++ b/KeyStats/zh-Hans.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "settings.dynamicIconColorStyle" = "启用后显示方式";
 "settings.dynamicIconColorStyle.icon" = "图标着色";
 "settings.dynamicIconColorStyle.dot" = "状态圆点";
+"settings.dynamicIconColorWindow" = "统计时间窗口 (秒)";
 "settings.dynamicIconColorHelp.title" = "动态颜色说明";
 "settings.dynamicIconColorHelp.body" = "根据近期输入速率自动计算颜色，并在菜单栏实时展示。\n\nAPM（每分钟输入事件数）颜色范围：\n• < 80：不着色（保持默认）\n• 80–160：从浅绿渐变到绿\n• 160–240：从黄渐变到红\n• ≥ 240：红色";
 "settings.windowTitle" = "KeyStats设置";


### PR DESCRIPTION
Allows users to customize the time window for the dynamic icon color calculation (1-3600s).

Updates rate calculation to handle initial ramp-up gracefully.

增加了时间窗口设置，能够平滑用户自定义时间段的活跃程度

fix #33 