### PR TITLE
fix: prevent numeric values from being truncated in popover

### DIFF
--- a/KeyStats/StatsPopoverViewController.swift
+++ b/KeyStats/StatsPopoverViewController.swift
@@ -706,6 +706,7 @@ struct AnimatedStatValueView: View {
                     .foregroundStyle(Color(nsColor: .systemBlue))
             }
         }
+        .fixedSize(horizontal: true, vertical: false)
         .animation(.default, value: viewModel.text)
     }
 }
@@ -736,6 +737,7 @@ struct AnimatedKeyCountView: View {
                     .foregroundStyle(Color(nsColor: .secondaryLabelColor))
             }
         }
+        .fixedSize(horizontal: true, vertical: false)
         .animation(.default, value: viewModel.text)
     }
 }


### PR DESCRIPTION
Add .fixedSize(horizontal: true, vertical: false) to AnimatedStatValueView and AnimatedKeyCountView to ensure numeric displays show full content.


<img width="440" height="706" alt="image" src="https://github.com/user-attachments/assets/8a5d5c4e-e6bc-4bbb-98e5-7fa868c2b87c" />


fix #38