### PR TITLE
fix(windows): unify standard window title bar theming

### DIFF
--- a/KeyStats.Windows/KeyStats/Views/MouseCalibrationWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/MouseCalibrationWindow.xaml.cs
@@ -4,7 +4,9 @@ using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Interop;
 using System.Windows.Threading;
+using KeyStats.Helpers;
 using KeyStats.Services;
 
 namespace KeyStats.Views;
@@ -31,6 +33,30 @@ public partial class MouseCalibrationWindow : Window
             Interval = TimeSpan.FromMilliseconds(33)
         };
         _liveTimer.Tick += (_, _) => UpdateLiveDistance();
+        Loaded += OnLoaded;
+        Closed += OnClosed;
+        ThemeManager.Instance.ThemeChanged += OnThemeChanged;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        ApplyWindowTitleBarTheme();
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        ThemeManager.Instance.ThemeChanged -= OnThemeChanged;
+    }
+
+    private void OnThemeChanged()
+    {
+        Dispatcher.BeginInvoke(new Action(ApplyWindowTitleBarTheme));
+    }
+
+    private void ApplyWindowTitleBarTheme()
+    {
+        var handle = new WindowInteropHelper(this).Handle;
+        NativeInterop.TrySetImmersiveDarkMode(handle, ThemeManager.Instance.IsDarkTheme);
     }
 
     private void LoadSettings()

--- a/KeyStats.Windows/KeyStats/Views/NotificationSettingsWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/NotificationSettingsWindow.xaml.cs
@@ -1,6 +1,8 @@
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Interop;
+using KeyStats.Helpers;
 using KeyStats.Services;
 
 namespace KeyStats.Views;
@@ -14,6 +16,30 @@ public partial class NotificationSettingsWindow : Window
         InitializeComponent();
         LoadSettings();
         _isLoading = false;
+        Loaded += OnLoaded;
+        Closed += OnClosed;
+        ThemeManager.Instance.ThemeChanged += OnThemeChanged;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        ApplyWindowTitleBarTheme();
+    }
+
+    private void OnClosed(object? sender, System.EventArgs e)
+    {
+        ThemeManager.Instance.ThemeChanged -= OnThemeChanged;
+    }
+
+    private void OnThemeChanged()
+    {
+        Dispatcher.BeginInvoke(new System.Action(ApplyWindowTitleBarTheme));
+    }
+
+    private void ApplyWindowTitleBarTheme()
+    {
+        var handle = new WindowInteropHelper(this).Handle;
+        NativeInterop.TrySetImmersiveDarkMode(handle, ThemeManager.Instance.IsDarkTheme);
     }
 
     private void LoadSettings()

--- a/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
@@ -1,5 +1,7 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Windows;
+using System.Windows.Interop;
+using KeyStats.Helpers;
 
 namespace KeyStats.Views;
 
@@ -10,6 +12,30 @@ public partial class SettingsWindow : Window
     public SettingsWindow()
     {
         InitializeComponent();
+        Loaded += OnLoaded;
+        Closed += OnClosed;
+        ThemeManager.Instance.ThemeChanged += OnThemeChanged;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        ApplyWindowTitleBarTheme();
+    }
+
+    private void OnClosed(object? sender, System.EventArgs e)
+    {
+        ThemeManager.Instance.ThemeChanged -= OnThemeChanged;
+    }
+
+    private void OnThemeChanged()
+    {
+        Dispatcher.BeginInvoke(new System.Action(ApplyWindowTitleBarTheme));
+    }
+
+    private void ApplyWindowTitleBarTheme()
+    {
+        var handle = new WindowInteropHelper(this).Handle;
+        NativeInterop.TrySetImmersiveDarkMode(handle, ThemeManager.Instance.IsDarkTheme);
     }
 
     private void OpenStats_Click(object sender, RoutedEventArgs e)

--- a/KeyStats.Windows/KeyStats/Views/StatsPopupWindow.xaml
+++ b/KeyStats.Windows/KeyStats/Views/StatsPopupWindow.xaml
@@ -22,7 +22,8 @@
         <viewmodels:StatsPopupViewModel/>
     </Window.DataContext>
 
-    <Border Background="{DynamicResource SurfaceBrush}"
+    <Border x:Name="RootBorder"
+            Background="{DynamicResource SurfaceBrush}"
             BorderThickness="0"
             CornerRadius="8">
         <ScrollViewer VerticalScrollBarVisibility="Auto"

--- a/KeyStats.Windows/KeyStats/Views/StatsPopupWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/StatsPopupWindow.xaml.cs
@@ -441,6 +441,11 @@ public partial class StatsPopupWindow : Window
 
     private void ConfigureWindowForMode()
     {
+        if (FindName("RootBorder") is System.Windows.Controls.Border rootBorder)
+        {
+            rootBorder.CornerRadius = _isWindowMode ? new CornerRadius(0) : new CornerRadius(8);
+        }
+
         if (_isWindowMode)
         {
             WindowStyle = WindowStyle.SingleBorderWindow;


### PR DESCRIPTION
## Summary
- apply the existing immersive dark title bar behavior to Settings, Notification Settings, and Mouse Calibration so standard windows follow the same theme treatment
- keep the main stats window aligned with the standard window path and fix its windowed-mode top corner artifact by removing the popup corner radius in that mode
- leave the custom transparent dialogs unchanged so only standard windows are normalized in this pass