### PR TITLE
fix(windows): harden stats persistence against power loss

### DIFF
--- a/KeyStats.Windows/KeyStats/Services/StatsManager.cs
+++ b/KeyStats.Windows/KeyStats/Services/StatsManager.cs
@@ -34,14 +34,17 @@ public class StatsManager : IDisposable
     private Timer? _midnightTimer;
     private Timer? _statsUpdateTimer;
     private Timer? _mouseMoveUpdateTimer;
+    private Timer? _settingsSaveTimer;
 
     private readonly double _saveInterval = 2000; // 2 seconds
     private readonly double _statsUpdateDebounceInterval = 300; // 0.3 seconds
     private readonly double _mouseMoveIdleUpdateInterval = 350; // 0.35 seconds
+    private readonly double _settingsSaveInterval = 500; // 0.5 seconds — collapses per-keystroke text-changed bursts
     private const int MaxMissingDayBackfillDays = 31;
     private bool _pendingSave;
     private bool _pendingStatsUpdate;
     private bool _pendingMouseMoveUpdate;
+    private bool _pendingSettingsSave;
 
     // KPS/CPS peak tracking (1-second sliding window)
     private readonly Queue<DateTime> _recentKeyTimestamps = new();
@@ -435,18 +438,28 @@ public class StatsManager : IDisposable
     private void SaveStats()
     {
         DailyStats statsSnapshot;
-        Dictionary<string, DailyStats> historySnapshot;
 
         lock (_lock)
         {
             statsSnapshot = CloneDailyStats(CurrentStats, CurrentStats.Date.Date);
+            // Mirror today's counters into the in-memory History dict so query paths
+            // that read from History stay in sync. The history *file* is no longer
+            // re-written here — past-day data only changes at day rollover / import /
+            // reset / shutdown, so writing it every 2s is wasted I/O.
             RecordCurrentStatsToHistory();
-            historySnapshot = CloneHistorySnapshot(History);
         }
 
         WriteJsonDurable(_statsFilePath, statsSnapshot, "stats");
+    }
 
-        SaveHistorySnapshot(historySnapshot);
+    private void SaveHistory()
+    {
+        Dictionary<string, DailyStats> snapshot;
+        lock (_lock)
+        {
+            snapshot = CloneHistorySnapshot(History);
+        }
+        WriteJsonDurable(_historyFilePath, snapshot, "history");
     }
 
     private DailyStats? LoadStats()
@@ -504,10 +517,6 @@ public class StatsManager : IDisposable
             kvp => CloneDailyStats(kvp.Value, kvp.Value.Date.Date));
     }
 
-    private void SaveHistorySnapshot(Dictionary<string, DailyStats> historySnapshot)
-    {
-        WriteJsonDurable(_historyFilePath, historySnapshot, "history");
-    }
 
     private Dictionary<string, DailyStats> LoadHistory()
     {
@@ -525,6 +534,35 @@ public class StatsManager : IDisposable
     }
 
     public void SaveSettings()
+    {
+        // UI call sites can fire per-keystroke (e.g. NotificationSettingsWindow's
+        // OnThresholdTextChanged), so debounce the durable write — otherwise every
+        // keystroke would block the UI thread on a synchronous FlushFileBuffers.
+        lock (_lock)
+        {
+            _pendingSettingsSave = true;
+
+            if (_settingsSaveTimer == null)
+            {
+                _settingsSaveTimer = new Timer(_settingsSaveInterval) { AutoReset = false };
+                _settingsSaveTimer.Elapsed += (_, _) =>
+                {
+                    lock (_lock)
+                    {
+                        if (!_pendingSettingsSave) return;
+                        _pendingSettingsSave = false;
+                    }
+
+                    FlushSettings();
+                };
+            }
+
+            _settingsSaveTimer.Stop();
+            _settingsSaveTimer.Start();
+        }
+    }
+
+    private void FlushSettings()
     {
         WriteJsonDurable(_settingsFilePath, Settings, "settings");
     }
@@ -724,6 +762,7 @@ public class StatsManager : IDisposable
         }
 
         SaveStats();
+        SaveHistory();
         NotifyStatsUpdate();
     }
 
@@ -972,18 +1011,16 @@ public class StatsManager : IDisposable
 
     private void ResetStats(DateTime date)
     {
-        Dictionary<string, DailyStats> historySnapshot;
         lock (_lock)
         {
             // 先保存旧数据到 History，避免丢失最后一次保存后的增量
             RecordCurrentStatsToHistory();
-            historySnapshot = CloneHistorySnapshot(History);
 
             // 然后创建新的统计对象
             CurrentStats = new DailyStats(date);
         }
 
-        SaveHistorySnapshot(historySnapshot);
+        SaveHistory();
         UpdateNotificationBaselines();
         NotifyStatsUpdate();
         SaveStats();
@@ -1038,6 +1075,9 @@ public class StatsManager : IDisposable
         }
 
         SaveStats();
+        // Persist History too — past-day data just changed (today's counters were
+        // archived and possibly missing days were back-filled).
+        SaveHistory();
     }
 
     #endregion
@@ -1710,8 +1750,17 @@ public class StatsManager : IDisposable
         _statsUpdateTimer?.Stop();
         _mouseMoveUpdateTimer?.Stop();
         _midnightTimer?.Stop();
+        _settingsSaveTimer?.Stop();
+
+        lock (_lock)
+        {
+            _pendingSave = false;
+            _pendingSettingsSave = false;
+        }
+
         SaveStats();
-        SaveSettings();
+        SaveHistory();
+        FlushSettings();
     }
 
     public void Dispose()
@@ -1721,6 +1770,7 @@ public class StatsManager : IDisposable
         _statsUpdateTimer?.Dispose();
         _mouseMoveUpdateTimer?.Dispose();
         _midnightTimer?.Dispose();
+        _settingsSaveTimer?.Dispose();
         _instance = null;
     }
 }

--- a/KeyStats.Windows/KeyStats/Services/StatsManager.cs
+++ b/KeyStats.Windows/KeyStats/Services/StatsManager.cs
@@ -444,8 +444,7 @@ public class StatsManager : IDisposable
             historySnapshot = CloneHistorySnapshot(History);
         }
 
-        var json = JsonSerializer.Serialize(statsSnapshot, new JsonSerializerOptions { WriteIndented = true });
-        WriteAllTextDurable(_statsFilePath, json, "stats");
+        WriteJsonDurable(_statsFilePath, statsSnapshot, "stats");
 
         SaveHistorySnapshot(historySnapshot);
     }
@@ -467,7 +466,10 @@ public class StatsManager : IDisposable
         if (History.TryGetValue(todayKey, out var fromHistory))
         {
             System.Diagnostics.Debug.WriteLine("Recovered daily_stats from history.json");
-            return CloneDailyStats(fromHistory, fromHistory.Date.Date);
+            // Force date to today: this branch only fires when history has a today-keyed
+            // entry, so a corrupt Date field shouldn't cause SynchronizeCurrentDay to
+            // discard the recovered counts on startup.
+            return CloneDailyStats(fromHistory, DateTime.Today);
         }
 
         return null;
@@ -504,8 +506,7 @@ public class StatsManager : IDisposable
 
     private void SaveHistorySnapshot(Dictionary<string, DailyStats> historySnapshot)
     {
-        var json = JsonSerializer.Serialize(historySnapshot, new JsonSerializerOptions { WriteIndented = true });
-        WriteAllTextDurable(_historyFilePath, json, "history");
+        WriteJsonDurable(_historyFilePath, historySnapshot, "history");
     }
 
     private Dictionary<string, DailyStats> LoadHistory()
@@ -525,8 +526,7 @@ public class StatsManager : IDisposable
 
     public void SaveSettings()
     {
-        var json = JsonSerializer.Serialize(Settings, new JsonSerializerOptions { WriteIndented = true });
-        WriteAllTextDurable(_settingsFilePath, json, "settings");
+        WriteJsonDurable(_settingsFilePath, Settings, "settings");
     }
 
     private AppSettings LoadSettings()
@@ -536,14 +536,18 @@ public class StatsManager : IDisposable
             ?? new AppSettings();
     }
 
-    private static void WriteAllTextDurable(string targetPath, string content, string contextLabel)
+    private static void WriteJsonDurable<T>(string targetPath, T value, string contextLabel)
     {
         var tempPath = targetPath + ".tmp";
         var backupPath = targetPath + ".bak";
-        var bytes = Encoding.UTF8.GetBytes(content);
 
         try
         {
+            // Serialize inside the try/catch — System.Text.Json throws on NaN/Infinity
+            // by default, and an autosave-thread escape would crash the app.
+            var json = JsonSerializer.Serialize(value, new JsonSerializerOptions { WriteIndented = true });
+            var bytes = Encoding.UTF8.GetBytes(json);
+
             // WriteThrough + Flush(true) ensures FlushFileBuffers is issued, so the
             // tmp file's data blocks are durable before we swap it in. Otherwise a
             // power loss right after Replace can leave a 0-byte / truncated target.

--- a/KeyStats.Windows/KeyStats/Services/StatsManager.cs
+++ b/KeyStats.Windows/KeyStats/Services/StatsManager.cs
@@ -444,45 +444,32 @@ public class StatsManager : IDisposable
             historySnapshot = CloneHistorySnapshot(History);
         }
 
-        try
-        {
-            var json = JsonSerializer.Serialize(statsSnapshot, new JsonSerializerOptions { WriteIndented = true });
-            var tempPath = _statsFilePath + ".tmp";
-            var backupPath = _statsFilePath + ".bak";
-            File.WriteAllText(tempPath, json);
-
-            if (File.Exists(_statsFilePath))
-            {
-                // Atomic replace: temp -> target, target -> backup
-                File.Replace(tempPath, _statsFilePath, backupPath);
-            }
-            else
-            {
-                File.Move(tempPath, _statsFilePath);
-            }
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"Error saving stats: {ex.Message}");
-        }
+        var json = JsonSerializer.Serialize(statsSnapshot, new JsonSerializerOptions { WriteIndented = true });
+        WriteAllTextDurable(_statsFilePath, json, "stats");
 
         SaveHistorySnapshot(historySnapshot);
     }
 
     private DailyStats? LoadStats()
     {
-        try
+        var primary = TryDeserialize<DailyStats>(_statsFilePath);
+        if (primary != null) return primary;
+
+        var backup = TryDeserialize<DailyStats>(_statsFilePath + ".bak");
+        if (backup != null)
         {
-            if (File.Exists(_statsFilePath))
-            {
-                var json = File.ReadAllText(_statsFilePath);
-                return JsonSerializer.Deserialize<DailyStats>(json);
-            }
+            System.Diagnostics.Debug.WriteLine("Recovered daily_stats from .bak");
+            return backup;
         }
-        catch (Exception ex)
+
+        // Last resort: today's entry in already-loaded History.
+        var todayKey = DateTime.Today.ToString("yyyy-MM-dd");
+        if (History.TryGetValue(todayKey, out var fromHistory))
         {
-            System.Diagnostics.Debug.WriteLine($"Error loading stats: {ex.Message}");
+            System.Diagnostics.Debug.WriteLine("Recovered daily_stats from history.json");
+            return CloneDailyStats(fromHistory, fromHistory.Date.Date);
         }
+
         return null;
     }
 
@@ -517,85 +504,90 @@ public class StatsManager : IDisposable
 
     private void SaveHistorySnapshot(Dictionary<string, DailyStats> historySnapshot)
     {
-        try
-        {
-            var json = JsonSerializer.Serialize(historySnapshot, new JsonSerializerOptions { WriteIndented = true });
-            var tempPath = _historyFilePath + ".tmp";
-            var backupPath = _historyFilePath + ".bak";
-            File.WriteAllText(tempPath, json);
-
-            if (File.Exists(_historyFilePath))
-            {
-                File.Replace(tempPath, _historyFilePath, backupPath);
-            }
-            else
-            {
-                File.Move(tempPath, _historyFilePath);
-            }
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"Error saving history: {ex.Message}");
-        }
+        var json = JsonSerializer.Serialize(historySnapshot, new JsonSerializerOptions { WriteIndented = true });
+        WriteAllTextDurable(_historyFilePath, json, "history");
     }
 
     private Dictionary<string, DailyStats> LoadHistory()
     {
-        try
+        var primary = TryDeserialize<Dictionary<string, DailyStats>>(_historyFilePath);
+        if (primary != null) return primary;
+
+        var backup = TryDeserialize<Dictionary<string, DailyStats>>(_historyFilePath + ".bak");
+        if (backup != null)
         {
-            if (File.Exists(_historyFilePath))
-            {
-                var json = File.ReadAllText(_historyFilePath);
-                var history = JsonSerializer.Deserialize<Dictionary<string, DailyStats>>(json) ?? new();
-                return history;
-            }
+            System.Diagnostics.Debug.WriteLine("Recovered history from .bak");
+            return backup;
         }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"Error loading history: {ex.Message}");
-        }
+
         return new();
     }
 
     public void SaveSettings()
     {
-        try
-        {
-            var json = JsonSerializer.Serialize(Settings, new JsonSerializerOptions { WriteIndented = true });
-            var tempPath = _settingsFilePath + ".tmp";
-            var backupPath = _settingsFilePath + ".bak";
-            File.WriteAllText(tempPath, json);
-
-            if (File.Exists(_settingsFilePath))
-            {
-                File.Replace(tempPath, _settingsFilePath, backupPath);
-            }
-            else
-            {
-                File.Move(tempPath, _settingsFilePath);
-            }
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"Error saving settings: {ex.Message}");
-        }
+        var json = JsonSerializer.Serialize(Settings, new JsonSerializerOptions { WriteIndented = true });
+        WriteAllTextDurable(_settingsFilePath, json, "settings");
     }
 
     private AppSettings LoadSettings()
     {
+        return TryDeserialize<AppSettings>(_settingsFilePath)
+            ?? TryDeserialize<AppSettings>(_settingsFilePath + ".bak")
+            ?? new AppSettings();
+    }
+
+    private static void WriteAllTextDurable(string targetPath, string content, string contextLabel)
+    {
+        var tempPath = targetPath + ".tmp";
+        var backupPath = targetPath + ".bak";
+        var bytes = Encoding.UTF8.GetBytes(content);
+
         try
         {
-            if (File.Exists(_settingsFilePath))
+            // WriteThrough + Flush(true) ensures FlushFileBuffers is issued, so the
+            // tmp file's data blocks are durable before we swap it in. Otherwise a
+            // power loss right after Replace can leave a 0-byte / truncated target.
+            using (var fs = new FileStream(
+                tempPath,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 4096,
+                options: FileOptions.WriteThrough))
             {
-                var json = File.ReadAllText(_settingsFilePath);
-                return JsonSerializer.Deserialize<AppSettings>(json) ?? new AppSettings();
+                fs.Write(bytes, 0, bytes.Length);
+                fs.Flush(true);
+            }
+
+            if (File.Exists(targetPath))
+            {
+                File.Replace(tempPath, targetPath, backupPath);
+            }
+            else
+            {
+                File.Move(tempPath, targetPath);
             }
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Error loading settings: {ex.Message}");
+            System.Diagnostics.Debug.WriteLine($"Error saving {contextLabel}: {ex.Message}");
         }
-        return new AppSettings();
+    }
+
+    private static T? TryDeserialize<T>(string path) where T : class
+    {
+        try
+        {
+            if (!File.Exists(path)) return null;
+            var json = File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(json)) return null;
+            return JsonSerializer.Deserialize<T>(json);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error loading {path}: {ex.Message}");
+            return null;
+        }
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- 修复 Windows 版断电后统计数据被清空的问题（#104）。
- 写入侧用 `FileStream(WriteThrough)` + `Flush(true)` 强制把 tmp 数据块落盘后再 `File.Replace`，避免断电留下 0 字节 / 截断的 JSON。
- 读取侧加多级回退：主文件 → `.bak` → （仅 daily_stats）从已加载的 `history.json` 反查今天的 entry。原先解析失败直接返回空对象，等于清零。

## Changes
`KeyStats.Windows/KeyStats/Services/StatsManager.cs`
- 新增 `WriteAllTextDurable`，三处 Save 路径（stats / history / settings）统一走持久化写入。
- 新增 `TryDeserialize<T>`，统一处理"文件不存在 / 空 / 解析异常"。
- `LoadStats` 失败时尝试 `.bak`，再尝试 history 中的今日 entry。
- `LoadHistory` / `LoadSettings` 失败时尝试 `.bak`。

## Notes
- `.bak` 是上一轮 save 的完整快照，最坏丢约 2s（保存防抖周期）的输入增量，而不是全部清零。
- history.json 仍每 2s 全量覆盖；如想再降一档断电窗口，可后续改成"仅跨日 / 导入 / 退出时写"。

## Test plan
- [ ] Windows 上 `dotnet build KeyStats/KeyStats.csproj -c Release` 通过。
- [ ] 模拟断电：写入瞬间强制断电（或在 .tmp 写入完成前 kill 进程并清空主文件），重启后数据可从 .bak 恢复。
- [ ] 模拟主文件 0 字节：手动把 `daily_stats.json` 截断为 0 字节，启动应从 .bak 或 history 恢复当日数据。
- [ ] 模拟 history.json 损坏：截断为非法 JSON，启动应从 history.bak 恢复。
- [ ] 正常使用一段时间，确认没有持久化退化或异常增多。

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)