### PR TITLE
feat(i18n): Windows app bilingual support (zh-Hans / English)

### DIFF
--- a/KeyStats.Windows/KeyStats/App.xaml.cs
+++ b/KeyStats.Windows/KeyStats/App.xaml.cs
@@ -137,7 +137,7 @@ public partial class App : System.Windows.Application
     {
         var menu = new System.Windows.Controls.ContextMenu();
 
-        var openMainWindowItem = new System.Windows.Controls.MenuItem { Header = "打开主界面" };
+        var openMainWindowItem = new System.Windows.Controls.MenuItem { Header = KeyStats.Properties.Strings.Tray_OpenMainWindow };
         openMainWindowItem.Click += (s, e) =>
         {
             TrackClick("context_menu_open_main_window");
@@ -145,7 +145,7 @@ public partial class App : System.Windows.Application
         };
         menu.Items.Add(openMainWindowItem);
 
-        var settingsItem = new System.Windows.Controls.MenuItem { Header = "设置" };
+        var settingsItem = new System.Windows.Controls.MenuItem { Header = KeyStats.Properties.Strings.Tray_Settings };
         settingsItem.Click += (s, e) =>
         {
             TrackClick("context_menu_settings");
@@ -155,7 +155,7 @@ public partial class App : System.Windows.Application
 
         var startupItem = new System.Windows.Controls.MenuItem
         {
-            Header = "开机启动",
+            Header = KeyStats.Properties.Strings.Tray_StartAtLogin,
             IsCheckable = true,
             IsChecked = StartupManager.Instance.IsEnabled
         };
@@ -178,7 +178,7 @@ public partial class App : System.Windows.Application
         };
         menu.Items.Add(startupItem);
 
-        var keyHistoryItem = new System.Windows.Controls.MenuItem { Header = "历史按键统计" };
+        var keyHistoryItem = new System.Windows.Controls.MenuItem { Header = KeyStats.Properties.Strings.Tray_KeyHistory };
         keyHistoryItem.Click += (s, e) =>
         {
             TrackClick("context_menu_key_history");
@@ -188,7 +188,7 @@ public partial class App : System.Windows.Application
 
         menu.Items.Add(new System.Windows.Controls.Separator());
 
-        var quitItem = new System.Windows.Controls.MenuItem { Header = "退出" };
+        var quitItem = new System.Windows.Controls.MenuItem { Header = KeyStats.Properties.Strings.Tray_Quit };
         quitItem.Click += (s, e) =>
         {
             TrackClick("context_menu_quit");
@@ -305,8 +305,8 @@ public partial class App : System.Windows.Application
         {
             var dialog = new SaveFileDialog
             {
-                Title = "导出数据",
-                Filter = "JSON 文件 (*.json)|*.json|所有文件 (*.*)|*.*",
+                Title = KeyStats.Properties.Strings.Dialog_ExportTitle,
+                Filter = KeyStats.Properties.Strings.Dialog_JsonFilter,
                 DefaultExt = ".json",
                 AddExtension = true,
                 FileName = MakeExportFileName()
@@ -336,8 +336,8 @@ public partial class App : System.Windows.Application
 
                 // 使用 Toast 通知显示导出成功
                 new ToastContentBuilder()
-                    .AddText("导出成功")
-                    .AddText($"数据已保存到 {Path.GetFileName(dialog.FileName)}")
+                    .AddText(KeyStats.Properties.Strings.Toast_ExportSuccess_Title)
+                    .AddText(string.Format(KeyStats.Properties.Strings.Toast_ExportSuccess_BodyFormat, Path.GetFileName(dialog.FileName)))
                     .Show();
             }
             finally
@@ -348,8 +348,8 @@ public partial class App : System.Windows.Application
         catch (Exception ex)
         {
             new ToastContentBuilder()
-                .AddText("导出失败")
-                .AddText($"无法导出数据：{ex.Message}")
+                .AddText(KeyStats.Properties.Strings.Toast_ExportFailed_Title)
+                .AddText(string.Format(KeyStats.Properties.Strings.Toast_ExportFailed_BodyFormat, ex.Message))
                 .Show();
         }
     }
@@ -366,8 +366,8 @@ public partial class App : System.Windows.Application
         {
             var dialog = new OpenFileDialog
             {
-                Title = "导入数据",
-                Filter = "JSON 文件 (*.json)|*.json|所有文件 (*.*)|*.*",
+                Title = KeyStats.Properties.Strings.Dialog_ImportTitle,
+                Filter = KeyStats.Properties.Strings.Dialog_JsonFilter,
                 DefaultExt = ".json",
                 CheckFileExists = true,
                 Multiselect = false
@@ -404,10 +404,12 @@ public partial class App : System.Windows.Application
                 var data = File.ReadAllBytes(selectedFile);
                 StatsManager.Instance.ImportStatsData(data, mode.Value);
 
-                var modeLabel = mode == StatsManager.ImportMode.Overwrite ? "覆盖" : "合并";
+                var modeLabel = mode == StatsManager.ImportMode.Overwrite
+                    ? KeyStats.Properties.Strings.ImportMode_Overwrite
+                    : KeyStats.Properties.Strings.ImportMode_Merge;
                 new ToastContentBuilder()
-                    .AddText("导入成功")
-                    .AddText($"已{modeLabel}导入统计数据：{Path.GetFileName(selectedFile)}")
+                    .AddText(KeyStats.Properties.Strings.Toast_ImportSuccess_Title)
+                    .AddText(string.Format(KeyStats.Properties.Strings.Toast_ImportSuccess_BodyFormat, modeLabel, Path.GetFileName(selectedFile)))
                     .Show();
 
                 return;
@@ -423,8 +425,8 @@ public partial class App : System.Windows.Application
         catch (Exception ex)
         {
             new ToastContentBuilder()
-                .AddText("导入失败")
-                .AddText($"无法导入数据：{ex.Message}")
+                .AddText(KeyStats.Properties.Strings.Toast_ImportFailed_Title)
+                .AddText(string.Format(KeyStats.Properties.Strings.Toast_ImportFailed_BodyFormat, ex.Message))
                 .Show();
         }
     }
@@ -496,7 +498,7 @@ public partial class App : System.Windows.Application
             shortcut.TargetPath = exePath;
             shortcut.WorkingDirectory = Path.GetDirectoryName(exePath);
             shortcut.WindowStyle = 1;
-            shortcut.Description = "KeyStats";
+            shortcut.Description = KeyStats.Properties.Strings.Shortcut_Description;
             shortcut.IconLocation = exePath;
             shortcut.Save();
         }

--- a/KeyStats.Windows/KeyStats/App.xaml.cs
+++ b/KeyStats.Windows/KeyStats/App.xaml.cs
@@ -85,8 +85,8 @@ public partial class App : System.Windows.Application
 
             if (!createdNew)
             {
-                // English fallback — keep simple and reliable for this edge case.
-                MessageBox.Show("KeyStats is already running.", "KeyStats",
+                MessageBox.Show(KeyStats.Properties.Strings.Error_AppAlreadyRunning,
+                                KeyStats.Properties.Strings.App_Name,
                                 MessageBoxButton.OK, MessageBoxImage.Information);
                 Shutdown();
                 return;

--- a/KeyStats.Windows/KeyStats/App.xaml.cs
+++ b/KeyStats.Windows/KeyStats/App.xaml.cs
@@ -64,12 +64,30 @@ public partial class App : System.Windows.Application
         {
             Console.WriteLine("KeyStats starting...");
 
-            // Ensure single instance
-            var mutex = new System.Threading.Mutex(true, "KeyStats_SingleInstance", out bool createdNew);
+            // Apply language preference BEFORE any UI loads.
+            // StatsManager.Instance triggers settings.json load on first access.
+            var preliminarySettings = StatsManager.Instance.Settings;
+            LocalizationManager.ApplyAtStartup(preliminarySettings.LanguagePreference);
+
+            // Ensure single instance — retry up to 3 attempts (500ms apart) so a
+            // language-switch relaunch doesn't lose the race against the old
+            // process's OnExit cleanup.
+            System.Threading.Mutex? mutex = null;
+            bool createdNew = false;
+            for (int attempt = 0; attempt < 3; attempt++)
+            {
+                mutex = new System.Threading.Mutex(true, "KeyStats_SingleInstance", out createdNew);
+                if (createdNew) break;
+                mutex.Dispose();
+                mutex = null;
+                System.Threading.Thread.Sleep(500);
+            }
+
             if (!createdNew)
             {
-                mutex.Dispose();
-                MessageBox.Show("按键统计已在运行中。", "按键统计", MessageBoxButton.OK, MessageBoxImage.Information);
+                // English fallback — keep simple and reliable for this edge case.
+                MessageBox.Show("KeyStats is already running.", "KeyStats",
+                                MessageBoxButton.OK, MessageBoxImage.Information);
                 Shutdown();
                 return;
             }
@@ -108,7 +126,9 @@ public partial class App : System.Windows.Application
         catch (Exception ex)
         {
             Console.WriteLine($"Error during startup: {ex}");
-            MessageBox.Show($"启动错误: {ex.Message}", "按键统计错误", MessageBoxButton.OK, MessageBoxImage.Error);
+            MessageBox.Show(string.Format(KeyStats.Properties.Strings.Error_StartupFailedFormat, ex.Message),
+                            KeyStats.Properties.Strings.Error_AppErrorTitle,
+                            MessageBoxButton.OK, MessageBoxImage.Error);
             Shutdown();
         }
     }

--- a/KeyStats.Windows/KeyStats/Helpers/LocalizationManager.cs
+++ b/KeyStats.Windows/KeyStats/Helpers/LocalizationManager.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace KeyStats.Helpers;
+
+public static class LocalizationManager
+{
+    // Must be called before any UI loads (typically at the top of App.OnStartup,
+    // after settings are loaded but before any window is constructed).
+    public static void ApplyAtStartup(string? languagePreference)
+    {
+        var culture = Resolve(languagePreference);
+        Thread.CurrentThread.CurrentUICulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        // CurrentCulture (number/date formats) is intentionally left as system default.
+    }
+
+    public static CultureInfo Resolve(string? preference)
+    {
+        return preference switch
+        {
+            "zh-Hans" => new CultureInfo("zh-Hans"),
+            "en"      => new CultureInfo("en"),
+            _         => DetectFromSystem(),  // "system", null, or any unknown value
+        };
+    }
+
+    private static CultureInfo DetectFromSystem()
+    {
+        var sys = CultureInfo.CurrentUICulture;
+        // Strict simplified Chinese only:
+        //   zh-CN, zh-Hans, zh-Hans-CN, zh → 中文
+        //   zh-TW, zh-HK, zh-Hant*, en-*, ja-*, etc. → English
+        if (sys.Name.StartsWith("zh-Hans", StringComparison.OrdinalIgnoreCase) ||
+            sys.Name.Equals("zh-CN", StringComparison.OrdinalIgnoreCase) ||
+            sys.Name.Equals("zh", StringComparison.OrdinalIgnoreCase))
+        {
+            return new CultureInfo("zh-Hans");
+        }
+        return new CultureInfo("en");
+    }
+}

--- a/KeyStats.Windows/KeyStats/KeyStats.csproj
+++ b/KeyStats.Windows/KeyStats/KeyStats.csproj
@@ -43,5 +43,13 @@
     <EmbeddedResource Include="Resources\Icons\tray-icon.png" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Strings.resx">
+      <ManifestResourceName>KeyStats.Properties.Strings</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Properties\Strings.zh-Hans.resx">
+      <ManifestResourceName>KeyStats.Properties.Strings.zh-Hans</ManifestResourceName>
+    </EmbeddedResource>
+  </ItemGroup>
 
 </Project>

--- a/KeyStats.Windows/KeyStats/Models/AppSettings.cs
+++ b/KeyStats.Windows/KeyStats/Models/AppSettings.cs
@@ -57,4 +57,7 @@ public class AppSettings
 
     [JsonPropertyName("mainWindowHeight")]
     public double? MainWindowHeight { get; set; }
+
+    [JsonPropertyName("languagePreference")]
+    public string LanguagePreference { get; set; } = "system";  // "system" | "zh-Hans" | "en"
 }

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -79,6 +79,7 @@ public static class Strings
     public static string Stats_MouseDistance => Get(nameof(Stats_MouseDistance));
     public static string Stats_ScrollDistance => Get(nameof(Stats_ScrollDistance));
     public static string Stats_KeyBreakdown => Get(nameof(Stats_KeyBreakdown));
+    public static string KeyBreakdown_Empty => Get(nameof(KeyBreakdown_Empty));
     public static string Stats_KeyboardHeatmap => Get(nameof(Stats_KeyboardHeatmap));
     public static string Stats_KeyHistory => Get(nameof(Stats_KeyHistory));
     public static string Stats_ActiveApps => Get(nameof(Stats_ActiveApps));
@@ -113,6 +114,9 @@ public static class Strings
     public static string History_TotalFormat => Get(nameof(History_TotalFormat));
     public static string KeyHistory_Empty => Get(nameof(KeyHistory_Empty));
     public static string KeyHistory_SummaryFormat => Get(nameof(KeyHistory_SummaryFormat));
+    public static string PieChart_Empty => Get(nameof(PieChart_Empty));
+    public static string PieChart_CountFormat => Get(nameof(PieChart_CountFormat));
+    public static string PieChart_PercentFormat => Get(nameof(PieChart_PercentFormat));
 
     public static string Heatmap_WindowTitle => Get(nameof(Heatmap_WindowTitle));
     public static string Heatmap_HeaderTitle => Get(nameof(Heatmap_HeaderTitle));

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -63,4 +63,5 @@ public static class Strings
     public static string Settings_DistanceCalibration => Get(nameof(Settings_DistanceCalibration));
     public static string Settings_DistanceCalibrationDesc => Get(nameof(Settings_DistanceCalibrationDesc));
     public static string Settings_VersionFormat => Get(nameof(Settings_VersionFormat));
+    public static string Settings_OpenGitHubFailedMessage => Get(nameof(Settings_OpenGitHubFailedMessage));
 }

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -22,4 +22,27 @@ public static class Strings
     public static string Error_AppAlreadyRunning => Get(nameof(Error_AppAlreadyRunning));
     public static string Error_StartupFailedFormat => Get(nameof(Error_StartupFailedFormat));
     public static string Error_AppErrorTitle => Get(nameof(Error_AppErrorTitle));
+
+    public static string Tray_OpenMainWindow => Get(nameof(Tray_OpenMainWindow));
+    public static string Tray_Settings => Get(nameof(Tray_Settings));
+    public static string Tray_StartAtLogin => Get(nameof(Tray_StartAtLogin));
+    public static string Tray_KeyHistory => Get(nameof(Tray_KeyHistory));
+    public static string Tray_Quit => Get(nameof(Tray_Quit));
+
+    public static string Toast_ExportSuccess_Title => Get(nameof(Toast_ExportSuccess_Title));
+    public static string Toast_ExportSuccess_BodyFormat => Get(nameof(Toast_ExportSuccess_BodyFormat));
+    public static string Toast_ExportFailed_Title => Get(nameof(Toast_ExportFailed_Title));
+    public static string Toast_ExportFailed_BodyFormat => Get(nameof(Toast_ExportFailed_BodyFormat));
+    public static string Toast_ImportSuccess_Title => Get(nameof(Toast_ImportSuccess_Title));
+    public static string Toast_ImportSuccess_BodyFormat => Get(nameof(Toast_ImportSuccess_BodyFormat));
+    public static string Toast_ImportFailed_Title => Get(nameof(Toast_ImportFailed_Title));
+    public static string Toast_ImportFailed_BodyFormat => Get(nameof(Toast_ImportFailed_BodyFormat));
+    public static string ImportMode_Overwrite => Get(nameof(ImportMode_Overwrite));
+    public static string ImportMode_Merge => Get(nameof(ImportMode_Merge));
+
+    public static string Shortcut_Description => Get(nameof(Shortcut_Description));
+
+    public static string Dialog_ExportTitle => Get(nameof(Dialog_ExportTitle));
+    public static string Dialog_ImportTitle => Get(nameof(Dialog_ImportTitle));
+    public static string Dialog_JsonFilter => Get(nameof(Dialog_JsonFilter));
 }

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -45,4 +45,10 @@ public static class Strings
     public static string Dialog_ExportTitle => Get(nameof(Dialog_ExportTitle));
     public static string Dialog_ImportTitle => Get(nameof(Dialog_ImportTitle));
     public static string Dialog_JsonFilter => Get(nameof(Dialog_JsonFilter));
+
+    public static string Settings_Language => Get(nameof(Settings_Language));
+    public static string Settings_LanguageDescription => Get(nameof(Settings_LanguageDescription));
+    public static string Settings_Language_System => Get(nameof(Settings_Language_System));
+    public static string Language_RestartPromptTitle => Get(nameof(Language_RestartPromptTitle));
+    public static string Language_RestartPromptMessage => Get(nameof(Language_RestartPromptMessage));
 }

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -1,0 +1,25 @@
+using System.Resources;
+
+namespace KeyStats.Properties;
+
+// Hand-written accessor class. Each migration task adds new properties here.
+// Returns the key name as fallback if a translation is missing — surfaces gaps loudly.
+public static class Strings
+{
+    private static readonly ResourceManager Rm =
+        new ResourceManager("KeyStats.Properties.Strings", typeof(Strings).Assembly);
+
+    private static string Get(string key) => Rm.GetString(key) ?? key;
+
+    public static string App_Name => Get(nameof(App_Name));
+    public static string Common_Ok => Get(nameof(Common_Ok));
+    public static string Common_Cancel => Get(nameof(Common_Cancel));
+    public static string Common_Close => Get(nameof(Common_Close));
+    public static string Common_Retry => Get(nameof(Common_Retry));
+    public static string Common_Open => Get(nameof(Common_Open));
+    public static string Common_Import => Get(nameof(Common_Import));
+    public static string Common_Export => Get(nameof(Common_Export));
+    public static string Error_AppAlreadyRunning => Get(nameof(Error_AppAlreadyRunning));
+    public static string Error_StartupFailedFormat => Get(nameof(Error_StartupFailedFormat));
+    public static string Error_AppErrorTitle => Get(nameof(Error_AppErrorTitle));
+}

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -12,10 +12,7 @@ public static class Strings
     private static string Get(string key) => Rm.GetString(key) ?? key;
 
     public static string App_Name => Get(nameof(App_Name));
-    public static string Common_Ok => Get(nameof(Common_Ok));
     public static string Common_Cancel => Get(nameof(Common_Cancel));
-    public static string Common_Close => Get(nameof(Common_Close));
-    public static string Common_Retry => Get(nameof(Common_Retry));
     public static string Common_Open => Get(nameof(Common_Open));
     public static string Common_Import => Get(nameof(Common_Import));
     public static string Common_Export => Get(nameof(Common_Export));
@@ -73,8 +70,6 @@ public static class Strings
     public static string Settings_OpenGitHubFailedMessage => Get(nameof(Settings_OpenGitHubFailedMessage));
 
     public static string Stats_TodayHeader => Get(nameof(Stats_TodayHeader));
-    public static string Stats_PeakKpsLabel => Get(nameof(Stats_PeakKpsLabel));
-    public static string Stats_PeakCpsLabel => Get(nameof(Stats_PeakCpsLabel));
     public static string Stats_KeyPresses => Get(nameof(Stats_KeyPresses));
     public static string Stats_MouseClicks => Get(nameof(Stats_MouseClicks));
     public static string Stats_MouseClickDetail => Get(nameof(Stats_MouseClickDetail));
@@ -149,19 +144,8 @@ public static class Strings
 
     public static string Calibration_WindowTitle => Get(nameof(Calibration_WindowTitle));
     public static string Calibration_HeaderTitle => Get(nameof(Calibration_HeaderTitle));
-    public static string Calibration_Instruction => Get(nameof(Calibration_Instruction));
-    public static string Calibration_StartTitle => Get(nameof(Calibration_StartTitle));
-    public static string Calibration_StartMessage => Get(nameof(Calibration_StartMessage));
     public static string Calibration_Start => Get(nameof(Calibration_Start));
-    public static string Calibration_FinishTitle => Get(nameof(Calibration_FinishTitle));
-    public static string Calibration_FinishMessage => Get(nameof(Calibration_FinishMessage));
     public static string Calibration_Finish => Get(nameof(Calibration_Finish));
-    public static string Calibration_SuccessTitle => Get(nameof(Calibration_SuccessTitle));
-    public static string Calibration_SuccessMessageFormat => Get(nameof(Calibration_SuccessMessageFormat));
-    public static string Calibration_FailureTitle => Get(nameof(Calibration_FailureTitle));
-    public static string Calibration_FailureMessage => Get(nameof(Calibration_FailureMessage));
-    public static string Calibration_StatusWaiting => Get(nameof(Calibration_StatusWaiting));
-    public static string Calibration_StatusMovingFormat => Get(nameof(Calibration_StatusMovingFormat));
 
     public static string Calibration_InstructionEnter => Get(nameof(Calibration_InstructionEnter));
     public static string Calibration_LengthLabel => Get(nameof(Calibration_LengthLabel));

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -103,4 +103,16 @@ public static class Strings
     public static string AppStats_Range30Days => Get(nameof(AppStats_Range30Days));
     public static string AppStats_RangeAll => Get(nameof(AppStats_RangeAll));
     public static string AppStats_ColumnApp => Get(nameof(AppStats_ColumnApp));
+
+    public static string Heatmap_WindowTitle => Get(nameof(Heatmap_WindowTitle));
+    public static string Heatmap_HeaderTitle => Get(nameof(Heatmap_HeaderTitle));
+    public static string Heatmap_HeaderSubtitle => Get(nameof(Heatmap_HeaderSubtitle));
+    public static string Heatmap_PrevDay => Get(nameof(Heatmap_PrevDay));
+    public static string Heatmap_NextDay => Get(nameof(Heatmap_NextDay));
+    public static string Heatmap_BackToToday => Get(nameof(Heatmap_BackToToday));
+    public static string Heatmap_NoData => Get(nameof(Heatmap_NoData));
+    public static string Heatmap_SummaryFormat => Get(nameof(Heatmap_SummaryFormat));
+    public static string Heatmap_DatePickerTooltip => Get(nameof(Heatmap_DatePickerTooltip));
+    public static string Heatmap_DateFormatShort => Get(nameof(Heatmap_DateFormatShort));
+    public static string Heatmap_DateFormatLong => Get(nameof(Heatmap_DateFormatLong));
 }

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -125,4 +125,39 @@ public static class Strings
     public static string History_Range_Last7Days => Get(nameof(History_Range_Last7Days));
     public static string History_Range_Last30Days => Get(nameof(History_Range_Last30Days));
     public static string History_Range_All => Get(nameof(History_Range_All));
+
+    public static string Calibration_WindowTitle => Get(nameof(Calibration_WindowTitle));
+    public static string Calibration_HeaderTitle => Get(nameof(Calibration_HeaderTitle));
+    public static string Calibration_Instruction => Get(nameof(Calibration_Instruction));
+    public static string Calibration_StartTitle => Get(nameof(Calibration_StartTitle));
+    public static string Calibration_StartMessage => Get(nameof(Calibration_StartMessage));
+    public static string Calibration_Start => Get(nameof(Calibration_Start));
+    public static string Calibration_FinishTitle => Get(nameof(Calibration_FinishTitle));
+    public static string Calibration_FinishMessage => Get(nameof(Calibration_FinishMessage));
+    public static string Calibration_Finish => Get(nameof(Calibration_Finish));
+    public static string Calibration_SuccessTitle => Get(nameof(Calibration_SuccessTitle));
+    public static string Calibration_SuccessMessageFormat => Get(nameof(Calibration_SuccessMessageFormat));
+    public static string Calibration_FailureTitle => Get(nameof(Calibration_FailureTitle));
+    public static string Calibration_FailureMessage => Get(nameof(Calibration_FailureMessage));
+    public static string Calibration_StatusWaiting => Get(nameof(Calibration_StatusWaiting));
+    public static string Calibration_StatusMovingFormat => Get(nameof(Calibration_StatusMovingFormat));
+
+    public static string Calibration_InstructionEnter => Get(nameof(Calibration_InstructionEnter));
+    public static string Calibration_LengthLabel => Get(nameof(Calibration_LengthLabel));
+    public static string Calibration_StepsLabel => Get(nameof(Calibration_StepsLabel));
+    public static string Calibration_StatusIdle => Get(nameof(Calibration_StatusIdle));
+    public static string Calibration_StatusRecording => Get(nameof(Calibration_StatusRecording));
+    public static string Calibration_StatusPressEnterFirst => Get(nameof(Calibration_StatusPressEnterFirst));
+    public static string Calibration_StatusMovementTooShort => Get(nameof(Calibration_StatusMovementTooShort));
+    public static string Calibration_StatusInvalidLength => Get(nameof(Calibration_StatusInvalidLength));
+    public static string Calibration_StatusComplete => Get(nameof(Calibration_StatusComplete));
+    public static string Calibration_DisplayUnitLabel => Get(nameof(Calibration_DisplayUnitLabel));
+    public static string Calibration_UnitAuto => Get(nameof(Calibration_UnitAuto));
+    public static string Calibration_UnitPixel => Get(nameof(Calibration_UnitPixel));
+    public static string Calibration_CurrentResultLabel => Get(nameof(Calibration_CurrentResultLabel));
+    public static string Calibration_PixelsLabelEmpty => Get(nameof(Calibration_PixelsLabelEmpty));
+    public static string Calibration_PixelsLabelFormat => Get(nameof(Calibration_PixelsLabelFormat));
+    public static string Calibration_ScaleLabelEmpty => Get(nameof(Calibration_ScaleLabelEmpty));
+    public static string Calibration_ScaleLabelFormat => Get(nameof(Calibration_ScaleLabelFormat));
+    public static string Calibration_TipFooter => Get(nameof(Calibration_TipFooter));
 }

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -64,4 +64,34 @@ public static class Strings
     public static string Settings_DistanceCalibrationDesc => Get(nameof(Settings_DistanceCalibrationDesc));
     public static string Settings_VersionFormat => Get(nameof(Settings_VersionFormat));
     public static string Settings_OpenGitHubFailedMessage => Get(nameof(Settings_OpenGitHubFailedMessage));
+
+    public static string Stats_TodayHeader => Get(nameof(Stats_TodayHeader));
+    public static string Stats_PeakKpsLabel => Get(nameof(Stats_PeakKpsLabel));
+    public static string Stats_PeakCpsLabel => Get(nameof(Stats_PeakCpsLabel));
+    public static string Stats_KeyPresses => Get(nameof(Stats_KeyPresses));
+    public static string Stats_MouseClicks => Get(nameof(Stats_MouseClicks));
+    public static string Stats_MouseClickDetail => Get(nameof(Stats_MouseClickDetail));
+    public static string Click_Left => Get(nameof(Click_Left));
+    public static string Click_Middle => Get(nameof(Click_Middle));
+    public static string Click_Right => Get(nameof(Click_Right));
+    public static string Click_Back => Get(nameof(Click_Back));
+    public static string Click_Forward => Get(nameof(Click_Forward));
+    public static string Stats_MouseDistance => Get(nameof(Stats_MouseDistance));
+    public static string Stats_ScrollDistance => Get(nameof(Stats_ScrollDistance));
+    public static string Stats_KeyBreakdown => Get(nameof(Stats_KeyBreakdown));
+    public static string Stats_KeyboardHeatmap => Get(nameof(Stats_KeyboardHeatmap));
+    public static string Stats_KeyHistory => Get(nameof(Stats_KeyHistory));
+    public static string Stats_ActiveApps => Get(nameof(Stats_ActiveApps));
+    public static string Stats_AppStatsDetail => Get(nameof(Stats_AppStatsDetail));
+    public static string Stats_HistoryHeader => Get(nameof(Stats_HistoryHeader));
+    public static string Chart_Line => Get(nameof(Chart_Line));
+    public static string Chart_Bar => Get(nameof(Chart_Bar));
+    public static string Range_7Days => Get(nameof(Range_7Days));
+    public static string Range_30Days => Get(nameof(Range_30Days));
+    public static string Metric_Clicks => Get(nameof(Metric_Clicks));
+    public static string Metric_Keys => Get(nameof(Metric_Keys));
+    public static string Metric_Move => Get(nameof(Metric_Move));
+    public static string Metric_Scroll => Get(nameof(Metric_Scroll));
+    public static string Stats_PeakKpsTooltipLabel => Get(nameof(Stats_PeakKpsTooltipLabel));
+    public static string Stats_PeakCpsTooltipLabel => Get(nameof(Stats_PeakCpsTooltipLabel));
 }

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -22,6 +22,13 @@ public static class Strings
     public static string Error_AppAlreadyRunning => Get(nameof(Error_AppAlreadyRunning));
     public static string Error_StartupFailedFormat => Get(nameof(Error_StartupFailedFormat));
     public static string Error_AppErrorTitle => Get(nameof(Error_AppErrorTitle));
+    public static string Error_ImportInvalidFormat => Get(nameof(Error_ImportInvalidFormat));
+    public static string Error_ImportUnsupportedVersion => Get(nameof(Error_ImportUnsupportedVersion));
+    public static string Error_ImportEmpty => Get(nameof(Error_ImportEmpty));
+
+    public static string Notif_ThresholdTitle => Get(nameof(Notif_ThresholdTitle));
+    public static string Notif_KeyThresholdReachedFormat => Get(nameof(Notif_KeyThresholdReachedFormat));
+    public static string Notif_ClickThresholdReachedFormat => Get(nameof(Notif_ClickThresholdReachedFormat));
 
     public static string Tray_OpenMainWindow => Get(nameof(Tray_OpenMainWindow));
     public static string Tray_Settings => Get(nameof(Tray_Settings));

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -51,4 +51,16 @@ public static class Strings
     public static string Settings_Language_System => Get(nameof(Settings_Language_System));
     public static string Language_RestartPromptTitle => Get(nameof(Language_RestartPromptTitle));
     public static string Language_RestartPromptMessage => Get(nameof(Language_RestartPromptMessage));
+
+    public static string Settings_WindowTitle => Get(nameof(Settings_WindowTitle));
+    public static string Settings_HeaderTitle => Get(nameof(Settings_HeaderTitle));
+    public static string Settings_HeaderSubtitle => Get(nameof(Settings_HeaderSubtitle));
+    public static string Settings_GitHubTooltip => Get(nameof(Settings_GitHubTooltip));
+    public static string Settings_DataImportExport => Get(nameof(Settings_DataImportExport));
+    public static string Settings_DataImportExportDesc => Get(nameof(Settings_DataImportExportDesc));
+    public static string Settings_Notifications => Get(nameof(Settings_Notifications));
+    public static string Settings_NotificationsDesc => Get(nameof(Settings_NotificationsDesc));
+    public static string Settings_DistanceCalibration => Get(nameof(Settings_DistanceCalibration));
+    public static string Settings_DistanceCalibrationDesc => Get(nameof(Settings_DistanceCalibrationDesc));
+    public static string Settings_VersionFormat => Get(nameof(Settings_VersionFormat));
 }

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -109,7 +109,6 @@ public static class Strings
     public static string AppStats_ColumnKeys => Get(nameof(AppStats_ColumnKeys));
     public static string AppStats_ColumnClicks => Get(nameof(AppStats_ColumnClicks));
     public static string AppStats_ColumnScroll => Get(nameof(AppStats_ColumnScroll));
-    public static string AppStats_SortIndicator => Get(nameof(AppStats_SortIndicator));
     public static string AppStats_SummaryFormat => Get(nameof(AppStats_SummaryFormat));
     public static string AppStats_Empty => Get(nameof(AppStats_Empty));
     public static string AppStats_UnknownApp => Get(nameof(AppStats_UnknownApp));
@@ -170,8 +169,7 @@ public static class Strings
     public static string NotifSettings_Enable => Get(nameof(NotifSettings_Enable));
     public static string NotifSettings_KeyCardTitle => Get(nameof(NotifSettings_KeyCardTitle));
     public static string NotifSettings_ClickCardTitle => Get(nameof(NotifSettings_ClickCardTitle));
-    public static string NotifSettings_EveryPrefix => Get(nameof(NotifSettings_EveryPrefix));
-    public static string NotifSettings_TimesSuffix => Get(nameof(NotifSettings_TimesSuffix));
+    public static string NotifSettings_EveryFormat => Get(nameof(NotifSettings_EveryFormat));
     public static string NotifSettings_Hint => Get(nameof(NotifSettings_Hint));
 
     public static string ImportDialog_HeaderTitle => Get(nameof(ImportDialog_HeaderTitle));

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -94,4 +94,13 @@ public static class Strings
     public static string Metric_Scroll => Get(nameof(Metric_Scroll));
     public static string Stats_PeakKpsTooltipLabel => Get(nameof(Stats_PeakKpsTooltipLabel));
     public static string Stats_PeakCpsTooltipLabel => Get(nameof(Stats_PeakCpsTooltipLabel));
+
+    public static string AppStats_WindowTitle => Get(nameof(AppStats_WindowTitle));
+    public static string AppStats_HeaderTitle => Get(nameof(AppStats_HeaderTitle));
+    public static string AppStats_HeaderSubtitle => Get(nameof(AppStats_HeaderSubtitle));
+    public static string AppStats_RangeToday => Get(nameof(AppStats_RangeToday));
+    public static string AppStats_Range7Days => Get(nameof(AppStats_Range7Days));
+    public static string AppStats_Range30Days => Get(nameof(AppStats_Range30Days));
+    public static string AppStats_RangeAll => Get(nameof(AppStats_RangeAll));
+    public static string AppStats_ColumnApp => Get(nameof(AppStats_ColumnApp));
 }

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -115,4 +115,14 @@ public static class Strings
     public static string Heatmap_DatePickerTooltip => Get(nameof(Heatmap_DatePickerTooltip));
     public static string Heatmap_DateFormatShort => Get(nameof(Heatmap_DateFormatShort));
     public static string Heatmap_DateFormatLong => Get(nameof(Heatmap_DateFormatLong));
+
+    public static string KeyHistory_WindowTitle => Get(nameof(KeyHistory_WindowTitle));
+    public static string KeyHistory_HeaderTitle => Get(nameof(KeyHistory_HeaderTitle));
+    public static string KeyHistory_HeaderSubtitle => Get(nameof(KeyHistory_HeaderSubtitle));
+    public static string KeyHistory_PieChartTitle => Get(nameof(KeyHistory_PieChartTitle));
+    public static string KeyHistory_BarChartTitle => Get(nameof(KeyHistory_BarChartTitle));
+    public static string History_Range_Today => Get(nameof(History_Range_Today));
+    public static string History_Range_Last7Days => Get(nameof(History_Range_Last7Days));
+    public static string History_Range_Last30Days => Get(nameof(History_Range_Last30Days));
+    public static string History_Range_All => Get(nameof(History_Range_All));
 }

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -160,4 +160,24 @@ public static class Strings
     public static string Calibration_ScaleLabelEmpty => Get(nameof(Calibration_ScaleLabelEmpty));
     public static string Calibration_ScaleLabelFormat => Get(nameof(Calibration_ScaleLabelFormat));
     public static string Calibration_TipFooter => Get(nameof(Calibration_TipFooter));
+
+    public static string NotifSettings_WindowTitle => Get(nameof(NotifSettings_WindowTitle));
+    public static string NotifSettings_HeaderTitle => Get(nameof(NotifSettings_HeaderTitle));
+    public static string NotifSettings_HeaderSubtitle => Get(nameof(NotifSettings_HeaderSubtitle));
+    public static string NotifSettings_Enable => Get(nameof(NotifSettings_Enable));
+    public static string NotifSettings_KeyCardTitle => Get(nameof(NotifSettings_KeyCardTitle));
+    public static string NotifSettings_ClickCardTitle => Get(nameof(NotifSettings_ClickCardTitle));
+    public static string NotifSettings_EveryPrefix => Get(nameof(NotifSettings_EveryPrefix));
+    public static string NotifSettings_TimesSuffix => Get(nameof(NotifSettings_TimesSuffix));
+    public static string NotifSettings_Hint => Get(nameof(NotifSettings_Hint));
+
+    public static string ImportDialog_HeaderTitle => Get(nameof(ImportDialog_HeaderTitle));
+    public static string ImportDialog_Description => Get(nameof(ImportDialog_Description));
+    public static string ImportDialog_OverwriteDesc => Get(nameof(ImportDialog_OverwriteDesc));
+    public static string ImportDialog_MergeDesc => Get(nameof(ImportDialog_MergeDesc));
+
+    public static string Confirm_DefaultHeaderTitle => Get(nameof(Confirm_DefaultHeaderTitle));
+    public static string Confirm_DefaultMessage => Get(nameof(Confirm_DefaultMessage));
+    public static string Confirm_DefaultTitle => Get(nameof(Confirm_DefaultTitle));
+    public static string Confirm_DefaultConfirm => Get(nameof(Confirm_DefaultConfirm));
 }

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -129,8 +129,6 @@ public static class Strings
     public static string Heatmap_NoData => Get(nameof(Heatmap_NoData));
     public static string Heatmap_SummaryFormat => Get(nameof(Heatmap_SummaryFormat));
     public static string Heatmap_DatePickerTooltip => Get(nameof(Heatmap_DatePickerTooltip));
-    public static string Heatmap_DateFormatShort => Get(nameof(Heatmap_DateFormatShort));
-    public static string Heatmap_DateFormatLong => Get(nameof(Heatmap_DateFormatLong));
 
     public static string KeyHistory_WindowTitle => Get(nameof(KeyHistory_WindowTitle));
     public static string KeyHistory_HeaderTitle => Get(nameof(KeyHistory_HeaderTitle));

--- a/KeyStats.Windows/KeyStats/Properties/Strings.cs
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.cs
@@ -103,6 +103,16 @@ public static class Strings
     public static string AppStats_Range30Days => Get(nameof(AppStats_Range30Days));
     public static string AppStats_RangeAll => Get(nameof(AppStats_RangeAll));
     public static string AppStats_ColumnApp => Get(nameof(AppStats_ColumnApp));
+    public static string AppStats_ColumnKeys => Get(nameof(AppStats_ColumnKeys));
+    public static string AppStats_ColumnClicks => Get(nameof(AppStats_ColumnClicks));
+    public static string AppStats_ColumnScroll => Get(nameof(AppStats_ColumnScroll));
+    public static string AppStats_SortIndicator => Get(nameof(AppStats_SortIndicator));
+    public static string AppStats_SummaryFormat => Get(nameof(AppStats_SummaryFormat));
+    public static string AppStats_Empty => Get(nameof(AppStats_Empty));
+    public static string AppStats_UnknownApp => Get(nameof(AppStats_UnknownApp));
+    public static string History_TotalFormat => Get(nameof(History_TotalFormat));
+    public static string KeyHistory_Empty => Get(nameof(KeyHistory_Empty));
+    public static string KeyHistory_SummaryFormat => Get(nameof(KeyHistory_SummaryFormat));
 
     public static string Heatmap_WindowTitle => Get(nameof(Heatmap_WindowTitle));
     public static string Heatmap_HeaderTitle => Get(nameof(Heatmap_HeaderTitle));

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -91,4 +91,16 @@
   <data name="Settings_Language_System" xml:space="preserve"><value>System</value></data>
   <data name="Language_RestartPromptTitle" xml:space="preserve"><value>Restart Required</value></data>
   <data name="Language_RestartPromptMessage" xml:space="preserve"><value>KeyStats needs to restart to apply the new language. Restart now?</value></data>
+
+  <data name="Settings_WindowTitle" xml:space="preserve"><value>Settings - KeyStats</value></data>
+  <data name="Settings_HeaderTitle" xml:space="preserve"><value>Settings</value></data>
+  <data name="Settings_HeaderSubtitle" xml:space="preserve"><value>Manage import/export and notification settings here</value></data>
+  <data name="Settings_GitHubTooltip" xml:space="preserve"><value>Open GitHub repository</value></data>
+  <data name="Settings_DataImportExport" xml:space="preserve"><value>Data Import / Export</value></data>
+  <data name="Settings_DataImportExportDesc" xml:space="preserve"><value>Import or export statistics from JSON</value></data>
+  <data name="Settings_Notifications" xml:space="preserve"><value>Notifications</value></data>
+  <data name="Settings_NotificationsDesc" xml:space="preserve"><value>Configure key/click threshold notifications</value></data>
+  <data name="Settings_DistanceCalibration" xml:space="preserve"><value>Distance Calibration</value></data>
+  <data name="Settings_DistanceCalibrationDesc" xml:space="preserve"><value>Calibrate the mouse movement coefficient</value></data>
+  <data name="Settings_VersionFormat" xml:space="preserve"><value>Current version {0}</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -85,4 +85,10 @@
   <data name="Dialog_ExportTitle" xml:space="preserve"><value>Export Data</value></data>
   <data name="Dialog_ImportTitle" xml:space="preserve"><value>Import Data</value></data>
   <data name="Dialog_JsonFilter" xml:space="preserve"><value>JSON Files (*.json)|*.json|All Files (*.*)|*.*</value></data>
+
+  <data name="Settings_Language" xml:space="preserve"><value>Language</value></data>
+  <data name="Settings_LanguageDescription" xml:space="preserve"><value>Display language for the app interface</value></data>
+  <data name="Settings_Language_System" xml:space="preserve"><value>System</value></data>
+  <data name="Language_RestartPromptTitle" xml:space="preserve"><value>Restart Required</value></data>
+  <data name="Language_RestartPromptMessage" xml:space="preserve"><value>KeyStats needs to restart to apply the new language. Restart now?</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -52,10 +52,7 @@
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
 
   <data name="App_Name" xml:space="preserve"><value>KeyStats</value></data>
-  <data name="Common_Ok" xml:space="preserve"><value>OK</value></data>
   <data name="Common_Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="Common_Close" xml:space="preserve"><value>Close</value></data>
-  <data name="Common_Retry" xml:space="preserve"><value>Retry</value></data>
   <data name="Common_Open" xml:space="preserve"><value>Open</value></data>
   <data name="Common_Import" xml:space="preserve"><value>Import</value></data>
   <data name="Common_Export" xml:space="preserve"><value>Export</value></data>
@@ -113,8 +110,6 @@
   <data name="Settings_OpenGitHubFailedMessage" xml:space="preserve"><value>Could not open the GitHub page.</value></data>
 
   <data name="Stats_TodayHeader" xml:space="preserve"><value>Today's Stats</value></data>
-  <data name="Stats_PeakKpsLabel" xml:space="preserve"><value>Peak KPS</value></data>
-  <data name="Stats_PeakCpsLabel" xml:space="preserve"><value>Peak CPS</value></data>
   <data name="Stats_KeyPresses" xml:space="preserve"><value>Key Presses</value></data>
   <data name="Stats_MouseClicks" xml:space="preserve"><value>Mouse Clicks</value></data>
   <data name="Stats_MouseClickDetail" xml:space="preserve"><value>Click Breakdown</value></data>
@@ -189,19 +184,8 @@
 
   <data name="Calibration_WindowTitle" xml:space="preserve"><value>Mouse Distance Calibration</value></data>
   <data name="Calibration_HeaderTitle" xml:space="preserve"><value>Mouse Distance Calibration</value></data>
-  <data name="Calibration_Instruction" xml:space="preserve"><value>Press any key to start recording, move 10 cm in a straight line, then press any key again to finish.</value></data>
-  <data name="Calibration_StartTitle" xml:space="preserve"><value>Mouse Distance Calibration</value></data>
-  <data name="Calibration_StartMessage" xml:space="preserve"><value>Prepare a 10 cm ruler. After clicking "Start", place the cursor at the start, press any key to begin recording, move 10 cm in a straight line, then press any key again to finish.</value></data>
   <data name="Calibration_Start" xml:space="preserve"><value>Start</value></data>
-  <data name="Calibration_FinishTitle" xml:space="preserve"><value>Calibration in Progress</value></data>
-  <data name="Calibration_FinishMessage" xml:space="preserve"><value>Move the mouse in a straight line for 10 cm, then click "Finish".</value></data>
   <data name="Calibration_Finish" xml:space="preserve"><value>Finish</value></data>
-  <data name="Calibration_SuccessTitle" xml:space="preserve"><value>Calibration Complete</value></data>
-  <data name="Calibration_SuccessMessageFormat" xml:space="preserve"><value>10 cm &#8776; {0}, factor updated to {1}.</value></data>
-  <data name="Calibration_FailureTitle" xml:space="preserve"><value>Calibration Failed</value></data>
-  <data name="Calibration_FailureMessage" xml:space="preserve"><value>Movement was too short or not detected. Please try again.</value></data>
-  <data name="Calibration_StatusWaiting" xml:space="preserve"><value>Press any key to start recording...</value></data>
-  <data name="Calibration_StatusMovingFormat" xml:space="preserve"><value>Moved {0}</value></data>
 
   <data name="Calibration_InstructionEnter" xml:space="preserve"><value>Press Enter to start recording, press Enter again to finish and compute the distance factor</value></data>
   <data name="Calibration_LengthLabel" xml:space="preserve"><value>Ruler Length</value></data>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -169,8 +169,6 @@
   <data name="Heatmap_NoData" xml:space="preserve"><value>No keyboard activity for this day</value></data>
   <data name="Heatmap_SummaryFormat" xml:space="preserve"><value>{0} key presses · {1} active keys</value></data>
   <data name="Heatmap_DatePickerTooltip" xml:space="preserve"><value>Select date</value></data>
-  <data name="Heatmap_DateFormatShort" xml:space="preserve"><value>{0}/{1}</value></data>
-  <data name="Heatmap_DateFormatLong" xml:space="preserve"><value>{0}/{1}/{2}</value></data>
 
   <data name="KeyHistory_WindowTitle" xml:space="preserve"><value>Key History</value></data>
   <data name="KeyHistory_HeaderTitle" xml:space="preserve"><value>Key History</value></data>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -149,7 +149,6 @@
   <data name="AppStats_ColumnKeys" xml:space="preserve"><value>Keys</value></data>
   <data name="AppStats_ColumnClicks" xml:space="preserve"><value>Clicks</value></data>
   <data name="AppStats_ColumnScroll" xml:space="preserve"><value>Scroll</value></data>
-  <data name="AppStats_SortIndicator" xml:space="preserve"><value>↓</value></data>
   <data name="AppStats_SummaryFormat" xml:space="preserve"><value>Total: {0} keys | {1} clicks | {2} scroll</value></data>
   <data name="AppStats_Empty" xml:space="preserve"><value>No app data yet</value></data>
   <data name="AppStats_UnknownApp" xml:space="preserve"><value>Unknown app</value></data>
@@ -211,8 +210,7 @@
   <data name="NotifSettings_Enable" xml:space="preserve"><value>Enable notifications</value></data>
   <data name="NotifSettings_KeyCardTitle" xml:space="preserve"><value>Key Press Notifications</value></data>
   <data name="NotifSettings_ClickCardTitle" xml:space="preserve"><value>Mouse Click Notifications</value></data>
-  <data name="NotifSettings_EveryPrefix" xml:space="preserve"><value>Every </value></data>
-  <data name="NotifSettings_TimesSuffix" xml:space="preserve"><value> times</value></data>
+  <data name="NotifSettings_EveryFormat" xml:space="preserve"><value>Every {0} times</value></data>
   <data name="NotifSettings_Hint" xml:space="preserve"><value>Example: set to 1000 to be notified at 1000, 2000, 3000…</value></data>
 
   <!-- ImportModeDialog -->

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -119,6 +119,7 @@
   <data name="Stats_MouseDistance" xml:space="preserve"><value>Mouse Distance</value></data>
   <data name="Stats_ScrollDistance" xml:space="preserve"><value>Scroll Distance</value></data>
   <data name="Stats_KeyBreakdown" xml:space="preserve"><value>Key Distribution</value></data>
+  <data name="KeyBreakdown_Empty" xml:space="preserve"><value>No key data yet</value></data>
   <data name="Stats_KeyboardHeatmap" xml:space="preserve"><value>Keyboard Heatmap</value></data>
   <data name="Stats_KeyHistory" xml:space="preserve"><value>Key History</value></data>
   <data name="Stats_ActiveApps" xml:space="preserve"><value>Active Apps</value></data>
@@ -153,6 +154,9 @@
   <data name="History_TotalFormat" xml:space="preserve"><value>Total: {0}</value></data>
   <data name="KeyHistory_Empty" xml:space="preserve"><value>No key history data yet</value></data>
   <data name="KeyHistory_SummaryFormat" xml:space="preserve"><value>Total keys: {0} · Distinct keys: {1}</value></data>
+  <data name="PieChart_Empty" xml:space="preserve"><value>No data</value></data>
+  <data name="PieChart_CountFormat" xml:space="preserve"><value>Count: {0}</value></data>
+  <data name="PieChart_PercentFormat" xml:space="preserve"><value>Share: {0}</value></data>
 
   <data name="Heatmap_WindowTitle" xml:space="preserve"><value>Keyboard Heatmap</value></data>
   <data name="Heatmap_HeaderTitle" xml:space="preserve"><value>Keyboard Heatmap</value></data>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -103,4 +103,5 @@
   <data name="Settings_DistanceCalibration" xml:space="preserve"><value>Distance Calibration</value></data>
   <data name="Settings_DistanceCalibrationDesc" xml:space="preserve"><value>Calibrate the mouse movement coefficient</value></data>
   <data name="Settings_VersionFormat" xml:space="preserve"><value>Current version {0}</value></data>
+  <data name="Settings_OpenGitHubFailedMessage" xml:space="preserve"><value>Could not open the GitHub page.</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -143,6 +143,16 @@
   <data name="AppStats_Range30Days" xml:space="preserve"><value>Last 30 days</value></data>
   <data name="AppStats_RangeAll" xml:space="preserve"><value>All</value></data>
   <data name="AppStats_ColumnApp" xml:space="preserve"><value>App</value></data>
+  <data name="AppStats_ColumnKeys" xml:space="preserve"><value>Keys</value></data>
+  <data name="AppStats_ColumnClicks" xml:space="preserve"><value>Clicks</value></data>
+  <data name="AppStats_ColumnScroll" xml:space="preserve"><value>Scroll</value></data>
+  <data name="AppStats_SortIndicator" xml:space="preserve"><value>↓</value></data>
+  <data name="AppStats_SummaryFormat" xml:space="preserve"><value>Total: {0} keys | {1} clicks | {2} scroll</value></data>
+  <data name="AppStats_Empty" xml:space="preserve"><value>No app data yet</value></data>
+  <data name="AppStats_UnknownApp" xml:space="preserve"><value>Unknown app</value></data>
+  <data name="History_TotalFormat" xml:space="preserve"><value>Total: {0}</value></data>
+  <data name="KeyHistory_Empty" xml:space="preserve"><value>No key history data yet</value></data>
+  <data name="KeyHistory_SummaryFormat" xml:space="preserve"><value>Total keys: {0} · Distinct keys: {1}</value></data>
 
   <data name="Heatmap_WindowTitle" xml:space="preserve"><value>Keyboard Heatmap</value></data>
   <data name="Heatmap_HeaderTitle" xml:space="preserve"><value>Keyboard Heatmap</value></data>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -155,4 +155,14 @@
   <data name="Heatmap_DatePickerTooltip" xml:space="preserve"><value>Select date</value></data>
   <data name="Heatmap_DateFormatShort" xml:space="preserve"><value>{0}/{1}</value></data>
   <data name="Heatmap_DateFormatLong" xml:space="preserve"><value>{0}/{1}/{2}</value></data>
+
+  <data name="KeyHistory_WindowTitle" xml:space="preserve"><value>Key History</value></data>
+  <data name="KeyHistory_HeaderTitle" xml:space="preserve"><value>Key History</value></data>
+  <data name="KeyHistory_HeaderSubtitle" xml:space="preserve"><value>Aggregated key counts only — no input content is recorded</value></data>
+  <data name="KeyHistory_PieChartTitle" xml:space="preserve"><value>Key share (pie)</value></data>
+  <data name="KeyHistory_BarChartTitle" xml:space="preserve"><value>Key counts (bar)</value></data>
+  <data name="History_Range_Today" xml:space="preserve"><value>Today</value></data>
+  <data name="History_Range_Last7Days" xml:space="preserve"><value>Last 7 days</value></data>
+  <data name="History_Range_Last30Days" xml:space="preserve"><value>Last 30 days</value></data>
+  <data name="History_Range_All" xml:space="preserve"><value>All</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -165,4 +165,39 @@
   <data name="History_Range_Last7Days" xml:space="preserve"><value>Last 7 days</value></data>
   <data name="History_Range_Last30Days" xml:space="preserve"><value>Last 30 days</value></data>
   <data name="History_Range_All" xml:space="preserve"><value>All</value></data>
+
+  <data name="Calibration_WindowTitle" xml:space="preserve"><value>Mouse Distance Calibration</value></data>
+  <data name="Calibration_HeaderTitle" xml:space="preserve"><value>Mouse Distance Calibration</value></data>
+  <data name="Calibration_Instruction" xml:space="preserve"><value>Press any key to start recording, move 10 cm in a straight line, then press any key again to finish.</value></data>
+  <data name="Calibration_StartTitle" xml:space="preserve"><value>Mouse Distance Calibration</value></data>
+  <data name="Calibration_StartMessage" xml:space="preserve"><value>Prepare a 10 cm ruler. After clicking "Start", place the cursor at the start, press any key to begin recording, move 10 cm in a straight line, then press any key again to finish.</value></data>
+  <data name="Calibration_Start" xml:space="preserve"><value>Start</value></data>
+  <data name="Calibration_FinishTitle" xml:space="preserve"><value>Calibration in Progress</value></data>
+  <data name="Calibration_FinishMessage" xml:space="preserve"><value>Move the mouse in a straight line for 10 cm, then click "Finish".</value></data>
+  <data name="Calibration_Finish" xml:space="preserve"><value>Finish</value></data>
+  <data name="Calibration_SuccessTitle" xml:space="preserve"><value>Calibration Complete</value></data>
+  <data name="Calibration_SuccessMessageFormat" xml:space="preserve"><value>10 cm &#8776; {0}, factor updated to {1}.</value></data>
+  <data name="Calibration_FailureTitle" xml:space="preserve"><value>Calibration Failed</value></data>
+  <data name="Calibration_FailureMessage" xml:space="preserve"><value>Movement was too short or not detected. Please try again.</value></data>
+  <data name="Calibration_StatusWaiting" xml:space="preserve"><value>Press any key to start recording...</value></data>
+  <data name="Calibration_StatusMovingFormat" xml:space="preserve"><value>Moved {0}</value></data>
+
+  <data name="Calibration_InstructionEnter" xml:space="preserve"><value>Press Enter to start recording, press Enter again to finish and compute the distance factor</value></data>
+  <data name="Calibration_LengthLabel" xml:space="preserve"><value>Ruler Length</value></data>
+  <data name="Calibration_StepsLabel" xml:space="preserve"><value>Calibration Steps</value></data>
+  <data name="Calibration_StatusIdle" xml:space="preserve"><value>Not started, press Enter to begin</value></data>
+  <data name="Calibration_StatusRecording" xml:space="preserve"><value>Recording, move the ruler length and press Enter to finish</value></data>
+  <data name="Calibration_StatusPressEnterFirst" xml:space="preserve"><value>Please press Enter to start first</value></data>
+  <data name="Calibration_StatusMovementTooShort" xml:space="preserve"><value>Movement was too short, please recalibrate</value></data>
+  <data name="Calibration_StatusInvalidLength" xml:space="preserve"><value>Invalid ruler length</value></data>
+  <data name="Calibration_StatusComplete" xml:space="preserve"><value>Calibration complete</value></data>
+  <data name="Calibration_DisplayUnitLabel" xml:space="preserve"><value>Display Unit</value></data>
+  <data name="Calibration_UnitAuto" xml:space="preserve"><value>Auto (cm/m/km)</value></data>
+  <data name="Calibration_UnitPixel" xml:space="preserve"><value>Pixels (px)</value></data>
+  <data name="Calibration_CurrentResultLabel" xml:space="preserve"><value>Current Result</value></data>
+  <data name="Calibration_PixelsLabelEmpty" xml:space="preserve"><value>Pixel distance: --</value></data>
+  <data name="Calibration_PixelsLabelFormat" xml:space="preserve"><value>Pixel distance: {0:F0} px</value></data>
+  <data name="Calibration_ScaleLabelEmpty" xml:space="preserve"><value>Scale factor: --</value></data>
+  <data name="Calibration_ScaleLabelFormat" xml:space="preserve"><value>Scale factor: {0:E4} m/px</value></data>
+  <data name="Calibration_TipFooter" xml:space="preserve"><value>Tip: for better accuracy, disable system mouse acceleration and move at a steady speed.</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -143,4 +143,16 @@
   <data name="AppStats_Range30Days" xml:space="preserve"><value>Last 30 days</value></data>
   <data name="AppStats_RangeAll" xml:space="preserve"><value>All</value></data>
   <data name="AppStats_ColumnApp" xml:space="preserve"><value>App</value></data>
+
+  <data name="Heatmap_WindowTitle" xml:space="preserve"><value>Keyboard Heatmap</value></data>
+  <data name="Heatmap_HeaderTitle" xml:space="preserve"><value>Keyboard Heatmap</value></data>
+  <data name="Heatmap_HeaderSubtitle" xml:space="preserve"><value>Full virtual keyboard view with daily key heat</value></data>
+  <data name="Heatmap_PrevDay" xml:space="preserve"><value>Previous day</value></data>
+  <data name="Heatmap_NextDay" xml:space="preserve"><value>Next day</value></data>
+  <data name="Heatmap_BackToToday" xml:space="preserve"><value>Today</value></data>
+  <data name="Heatmap_NoData" xml:space="preserve"><value>No keyboard activity for this day</value></data>
+  <data name="Heatmap_SummaryFormat" xml:space="preserve"><value>{0} key presses · {1} active keys</value></data>
+  <data name="Heatmap_DatePickerTooltip" xml:space="preserve"><value>Select date</value></data>
+  <data name="Heatmap_DateFormatShort" xml:space="preserve"><value>{0}/{1}</value></data>
+  <data name="Heatmap_DateFormatLong" xml:space="preserve"><value>{0}/{1}/{2}</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -134,4 +134,13 @@
   <data name="Metric_Scroll" xml:space="preserve"><value>Scroll</value></data>
   <data name="Stats_PeakKpsTooltipLabel" xml:space="preserve"><value>Peak Keys/sec (KPS)</value></data>
   <data name="Stats_PeakCpsTooltipLabel" xml:space="preserve"><value>Peak Clicks/sec (CPS)</value></data>
+
+  <data name="AppStats_WindowTitle" xml:space="preserve"><value>App Stats</value></data>
+  <data name="AppStats_HeaderTitle" xml:space="preserve"><value>App Stats</value></data>
+  <data name="AppStats_HeaderSubtitle" xml:space="preserve"><value>Per-app keyboard/click/scroll stats; only aggregates are saved</value></data>
+  <data name="AppStats_RangeToday" xml:space="preserve"><value>Today</value></data>
+  <data name="AppStats_Range7Days" xml:space="preserve"><value>Last 7 days</value></data>
+  <data name="AppStats_Range30Days" xml:space="preserve"><value>Last 30 days</value></data>
+  <data name="AppStats_RangeAll" xml:space="preserve"><value>All</value></data>
+  <data name="AppStats_ColumnApp" xml:space="preserve"><value>App</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -62,4 +62,27 @@
   <data name="Error_AppAlreadyRunning" xml:space="preserve"><value>KeyStats is already running.</value></data>
   <data name="Error_StartupFailedFormat" xml:space="preserve"><value>Startup error: {0}</value></data>
   <data name="Error_AppErrorTitle" xml:space="preserve"><value>KeyStats Error</value></data>
+
+  <data name="Tray_OpenMainWindow" xml:space="preserve"><value>Open Main Window</value></data>
+  <data name="Tray_Settings" xml:space="preserve"><value>Settings</value></data>
+  <data name="Tray_StartAtLogin" xml:space="preserve"><value>Start at Login</value></data>
+  <data name="Tray_KeyHistory" xml:space="preserve"><value>Key History</value></data>
+  <data name="Tray_Quit" xml:space="preserve"><value>Quit</value></data>
+
+  <data name="Toast_ExportSuccess_Title" xml:space="preserve"><value>Export Successful</value></data>
+  <data name="Toast_ExportSuccess_BodyFormat" xml:space="preserve"><value>Data saved to {0}</value></data>
+  <data name="Toast_ExportFailed_Title" xml:space="preserve"><value>Export Failed</value></data>
+  <data name="Toast_ExportFailed_BodyFormat" xml:space="preserve"><value>Could not export data: {0}</value></data>
+  <data name="Toast_ImportSuccess_Title" xml:space="preserve"><value>Import Successful</value></data>
+  <data name="Toast_ImportSuccess_BodyFormat" xml:space="preserve"><value>Statistics imported via {0}: {1}</value></data>
+  <data name="Toast_ImportFailed_Title" xml:space="preserve"><value>Import Failed</value></data>
+  <data name="Toast_ImportFailed_BodyFormat" xml:space="preserve"><value>Could not import data: {0}</value></data>
+  <data name="ImportMode_Overwrite" xml:space="preserve"><value>Overwrite</value></data>
+  <data name="ImportMode_Merge" xml:space="preserve"><value>Merge</value></data>
+
+  <data name="Shortcut_Description" xml:space="preserve"><value>KeyStats</value></data>
+
+  <data name="Dialog_ExportTitle" xml:space="preserve"><value>Export Data</value></data>
+  <data name="Dialog_ImportTitle" xml:space="preserve"><value>Import Data</value></data>
+  <data name="Dialog_JsonFilter" xml:space="preserve"><value>JSON Files (*.json)|*.json|All Files (*.*)|*.*</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -200,4 +200,27 @@
   <data name="Calibration_ScaleLabelEmpty" xml:space="preserve"><value>Scale factor: --</value></data>
   <data name="Calibration_ScaleLabelFormat" xml:space="preserve"><value>Scale factor: {0:E4} m/px</value></data>
   <data name="Calibration_TipFooter" xml:space="preserve"><value>Tip: for better accuracy, disable system mouse acceleration and move at a steady speed.</value></data>
+
+  <!-- NotificationSettingsWindow -->
+  <data name="NotifSettings_WindowTitle" xml:space="preserve"><value>Notification Settings - KeyStats</value></data>
+  <data name="NotifSettings_HeaderTitle" xml:space="preserve"><value>Notification Settings</value></data>
+  <data name="NotifSettings_HeaderSubtitle" xml:space="preserve"><value>Get notified each time the key or click count reaches the configured threshold</value></data>
+  <data name="NotifSettings_Enable" xml:space="preserve"><value>Enable notifications</value></data>
+  <data name="NotifSettings_KeyCardTitle" xml:space="preserve"><value>Key Press Notifications</value></data>
+  <data name="NotifSettings_ClickCardTitle" xml:space="preserve"><value>Mouse Click Notifications</value></data>
+  <data name="NotifSettings_EveryPrefix" xml:space="preserve"><value>Every </value></data>
+  <data name="NotifSettings_TimesSuffix" xml:space="preserve"><value> times</value></data>
+  <data name="NotifSettings_Hint" xml:space="preserve"><value>Example: set to 1000 to be notified at 1000, 2000, 3000…</value></data>
+
+  <!-- ImportModeDialog -->
+  <data name="ImportDialog_HeaderTitle" xml:space="preserve"><value>Choose Import Mode</value></data>
+  <data name="ImportDialog_Description" xml:space="preserve"><value>Choose how to handle the imported data:</value></data>
+  <data name="ImportDialog_OverwriteDesc" xml:space="preserve"><value>Delete existing data and replace it with the imported data</value></data>
+  <data name="ImportDialog_MergeDesc" xml:space="preserve"><value>Keep existing data and accumulate the imported data into it</value></data>
+
+  <!-- ConfirmDialog -->
+  <data name="Confirm_DefaultHeaderTitle" xml:space="preserve"><value>Confirm Action</value></data>
+  <data name="Confirm_DefaultMessage" xml:space="preserve"><value>Are you sure you want to perform this action?</value></data>
+  <data name="Confirm_DefaultTitle" xml:space="preserve"><value>Confirm</value></data>
+  <data name="Confirm_DefaultConfirm" xml:space="preserve"><value>OK</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -62,6 +62,13 @@
   <data name="Error_AppAlreadyRunning" xml:space="preserve"><value>KeyStats is already running.</value></data>
   <data name="Error_StartupFailedFormat" xml:space="preserve"><value>Startup error: {0}</value></data>
   <data name="Error_AppErrorTitle" xml:space="preserve"><value>KeyStats Error</value></data>
+  <data name="Error_ImportInvalidFormat" xml:space="preserve"><value>Data format is invalid.</value></data>
+  <data name="Error_ImportUnsupportedVersion" xml:space="preserve"><value>Unsupported export version.</value></data>
+  <data name="Error_ImportEmpty" xml:space="preserve"><value>Selected file is empty.</value></data>
+
+  <data name="Notif_ThresholdTitle" xml:space="preserve"><value>KeyStats Reminder</value></data>
+  <data name="Notif_KeyThresholdReachedFormat" xml:space="preserve"><value>Today's key presses reached {0:N0}.</value></data>
+  <data name="Notif_ClickThresholdReachedFormat" xml:space="preserve"><value>Today's clicks reached {0:N0}.</value></data>
 
   <data name="Tray_OpenMainWindow" xml:space="preserve"><value>Open Main Window</value></data>
   <data name="Tray_Settings" xml:space="preserve"><value>Settings</value></data>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -104,4 +104,34 @@
   <data name="Settings_DistanceCalibrationDesc" xml:space="preserve"><value>Calibrate the mouse movement coefficient</value></data>
   <data name="Settings_VersionFormat" xml:space="preserve"><value>Current version {0}</value></data>
   <data name="Settings_OpenGitHubFailedMessage" xml:space="preserve"><value>Could not open the GitHub page.</value></data>
+
+  <data name="Stats_TodayHeader" xml:space="preserve"><value>Today's Stats</value></data>
+  <data name="Stats_PeakKpsLabel" xml:space="preserve"><value>Peak KPS</value></data>
+  <data name="Stats_PeakCpsLabel" xml:space="preserve"><value>Peak CPS</value></data>
+  <data name="Stats_KeyPresses" xml:space="preserve"><value>Key Presses</value></data>
+  <data name="Stats_MouseClicks" xml:space="preserve"><value>Mouse Clicks</value></data>
+  <data name="Stats_MouseClickDetail" xml:space="preserve"><value>Click Breakdown</value></data>
+  <data name="Click_Left" xml:space="preserve"><value>Left</value></data>
+  <data name="Click_Middle" xml:space="preserve"><value>Middle</value></data>
+  <data name="Click_Right" xml:space="preserve"><value>Right</value></data>
+  <data name="Click_Back" xml:space="preserve"><value>Back</value></data>
+  <data name="Click_Forward" xml:space="preserve"><value>Forward</value></data>
+  <data name="Stats_MouseDistance" xml:space="preserve"><value>Mouse Distance</value></data>
+  <data name="Stats_ScrollDistance" xml:space="preserve"><value>Scroll Distance</value></data>
+  <data name="Stats_KeyBreakdown" xml:space="preserve"><value>Key Distribution</value></data>
+  <data name="Stats_KeyboardHeatmap" xml:space="preserve"><value>Keyboard Heatmap</value></data>
+  <data name="Stats_KeyHistory" xml:space="preserve"><value>Key History</value></data>
+  <data name="Stats_ActiveApps" xml:space="preserve"><value>Active Apps</value></data>
+  <data name="Stats_AppStatsDetail" xml:space="preserve"><value>App Stats Details</value></data>
+  <data name="Stats_HistoryHeader" xml:space="preserve"><value>History</value></data>
+  <data name="Chart_Line" xml:space="preserve"><value>Line</value></data>
+  <data name="Chart_Bar" xml:space="preserve"><value>Bar</value></data>
+  <data name="Range_7Days" xml:space="preserve"><value>7 days</value></data>
+  <data name="Range_30Days" xml:space="preserve"><value>30 days</value></data>
+  <data name="Metric_Clicks" xml:space="preserve"><value>Clicks</value></data>
+  <data name="Metric_Keys" xml:space="preserve"><value>Keys</value></data>
+  <data name="Metric_Move" xml:space="preserve"><value>Move</value></data>
+  <data name="Metric_Scroll" xml:space="preserve"><value>Scroll</value></data>
+  <data name="Stats_PeakKpsTooltipLabel" xml:space="preserve"><value>Peak Keys/sec (KPS)</value></data>
+  <data name="Stats_PeakCpsTooltipLabel" xml:space="preserve"><value>Peak Clicks/sec (CPS)</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.resx
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+
+  <data name="App_Name" xml:space="preserve"><value>KeyStats</value></data>
+  <data name="Common_Ok" xml:space="preserve"><value>OK</value></data>
+  <data name="Common_Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Common_Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Common_Retry" xml:space="preserve"><value>Retry</value></data>
+  <data name="Common_Open" xml:space="preserve"><value>Open</value></data>
+  <data name="Common_Import" xml:space="preserve"><value>Import</value></data>
+  <data name="Common_Export" xml:space="preserve"><value>Export</value></data>
+  <data name="Error_AppAlreadyRunning" xml:space="preserve"><value>KeyStats is already running.</value></data>
+  <data name="Error_StartupFailedFormat" xml:space="preserve"><value>Startup error: {0}</value></data>
+  <data name="Error_AppErrorTitle" xml:space="preserve"><value>KeyStats Error</value></data>
+</root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -91,4 +91,16 @@
   <data name="Settings_Language_System" xml:space="preserve"><value>跟随系统</value></data>
   <data name="Language_RestartPromptTitle" xml:space="preserve"><value>需要重启</value></data>
   <data name="Language_RestartPromptMessage" xml:space="preserve"><value>需要重启 KeyStats 才能切换语言。是否立即重启？</value></data>
+
+  <data name="Settings_WindowTitle" xml:space="preserve"><value>设置 - KeyStats</value></data>
+  <data name="Settings_HeaderTitle" xml:space="preserve"><value>设置</value></data>
+  <data name="Settings_HeaderSubtitle" xml:space="preserve"><value>在这里管理导入导出与通知设置</value></data>
+  <data name="Settings_GitHubTooltip" xml:space="preserve"><value>打开 GitHub 仓库</value></data>
+  <data name="Settings_DataImportExport" xml:space="preserve"><value>数据导入 / 导出</value></data>
+  <data name="Settings_DataImportExportDesc" xml:space="preserve"><value>从 JSON 导入或导出统计数据</value></data>
+  <data name="Settings_Notifications" xml:space="preserve"><value>通知设置</value></data>
+  <data name="Settings_NotificationsDesc" xml:space="preserve"><value>设置按键/点击阈值通知</value></data>
+  <data name="Settings_DistanceCalibration" xml:space="preserve"><value>距离校准</value></data>
+  <data name="Settings_DistanceCalibrationDesc" xml:space="preserve"><value>校准鼠标移动距离系数</value></data>
+  <data name="Settings_VersionFormat" xml:space="preserve"><value>当前版本 {0}</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -155,4 +155,14 @@
   <data name="Heatmap_DatePickerTooltip" xml:space="preserve"><value>选择日期</value></data>
   <data name="Heatmap_DateFormatShort" xml:space="preserve"><value>{0}月{1}日</value></data>
   <data name="Heatmap_DateFormatLong" xml:space="preserve"><value>{0}年{1}月{2}日</value></data>
+
+  <data name="KeyHistory_WindowTitle" xml:space="preserve"><value>历史按键统计</value></data>
+  <data name="KeyHistory_HeaderTitle" xml:space="preserve"><value>历史按键统计</value></data>
+  <data name="KeyHistory_HeaderSubtitle" xml:space="preserve"><value>按键数量聚合统计，仅展示计数，不记录输入内容</value></data>
+  <data name="KeyHistory_PieChartTitle" xml:space="preserve"><value>按键占比（饼图）</value></data>
+  <data name="KeyHistory_BarChartTitle" xml:space="preserve"><value>按键次数（柱状图）</value></data>
+  <data name="History_Range_Today" xml:space="preserve"><value>今天</value></data>
+  <data name="History_Range_Last7Days" xml:space="preserve"><value>过去7天</value></data>
+  <data name="History_Range_Last30Days" xml:space="preserve"><value>过去30天</value></data>
+  <data name="History_Range_All" xml:space="preserve"><value>全部</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -134,4 +134,13 @@
   <data name="Metric_Scroll" xml:space="preserve"><value>滚动</value></data>
   <data name="Stats_PeakKpsTooltipLabel" xml:space="preserve"><value>峰值按键速度(KPS)</value></data>
   <data name="Stats_PeakCpsTooltipLabel" xml:space="preserve"><value>峰值点击速度(CPS)</value></data>
+
+  <data name="AppStats_WindowTitle" xml:space="preserve"><value>按应用统计</value></data>
+  <data name="AppStats_HeaderTitle" xml:space="preserve"><value>按应用统计</value></data>
+  <data name="AppStats_HeaderSubtitle" xml:space="preserve"><value>按应用统计键盘/点击/滚动，仅保存聚合数据</value></data>
+  <data name="AppStats_RangeToday" xml:space="preserve"><value>今天</value></data>
+  <data name="AppStats_Range7Days" xml:space="preserve"><value>过去7天</value></data>
+  <data name="AppStats_Range30Days" xml:space="preserve"><value>过去30天</value></data>
+  <data name="AppStats_RangeAll" xml:space="preserve"><value>全部</value></data>
+  <data name="AppStats_ColumnApp" xml:space="preserve"><value>应用</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -149,7 +149,6 @@
   <data name="AppStats_ColumnKeys" xml:space="preserve"><value>键盘</value></data>
   <data name="AppStats_ColumnClicks" xml:space="preserve"><value>点击</value></data>
   <data name="AppStats_ColumnScroll" xml:space="preserve"><value>滚轮</value></data>
-  <data name="AppStats_SortIndicator" xml:space="preserve"><value>↓</value></data>
   <data name="AppStats_SummaryFormat" xml:space="preserve"><value>总计: {0} 键盘 | {1} 点击 | {2} 滚动</value></data>
   <data name="AppStats_Empty" xml:space="preserve"><value>暂无应用数据</value></data>
   <data name="AppStats_UnknownApp" xml:space="preserve"><value>未知应用</value></data>
@@ -211,8 +210,7 @@
   <data name="NotifSettings_Enable" xml:space="preserve"><value>启用通知</value></data>
   <data name="NotifSettings_KeyCardTitle" xml:space="preserve"><value>按键次数通知</value></data>
   <data name="NotifSettings_ClickCardTitle" xml:space="preserve"><value>鼠标点击通知</value></data>
-  <data name="NotifSettings_EveryPrefix" xml:space="preserve"><value>每 </value></data>
-  <data name="NotifSettings_TimesSuffix" xml:space="preserve"><value> 次通知一次</value></data>
+  <data name="NotifSettings_EveryFormat" xml:space="preserve"><value>每 {0} 次通知一次</value></data>
   <data name="NotifSettings_Hint" xml:space="preserve"><value>例如：设为 1000，则在 1000、2000、3000… 次时通知。</value></data>
 
   <!-- ImportModeDialog -->

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -143,6 +143,16 @@
   <data name="AppStats_Range30Days" xml:space="preserve"><value>过去30天</value></data>
   <data name="AppStats_RangeAll" xml:space="preserve"><value>全部</value></data>
   <data name="AppStats_ColumnApp" xml:space="preserve"><value>应用</value></data>
+  <data name="AppStats_ColumnKeys" xml:space="preserve"><value>键盘</value></data>
+  <data name="AppStats_ColumnClicks" xml:space="preserve"><value>点击</value></data>
+  <data name="AppStats_ColumnScroll" xml:space="preserve"><value>滚轮</value></data>
+  <data name="AppStats_SortIndicator" xml:space="preserve"><value>↓</value></data>
+  <data name="AppStats_SummaryFormat" xml:space="preserve"><value>总计: {0} 键盘 | {1} 点击 | {2} 滚动</value></data>
+  <data name="AppStats_Empty" xml:space="preserve"><value>暂无应用数据</value></data>
+  <data name="AppStats_UnknownApp" xml:space="preserve"><value>未知应用</value></data>
+  <data name="History_TotalFormat" xml:space="preserve"><value>总计: {0}</value></data>
+  <data name="KeyHistory_Empty" xml:space="preserve"><value>暂无历史按键数据</value></data>
+  <data name="KeyHistory_SummaryFormat" xml:space="preserve"><value>总按键: {0} · 按键种类: {1}</value></data>
 
   <data name="Heatmap_WindowTitle" xml:space="preserve"><value>键盘热力图</value></data>
   <data name="Heatmap_HeaderTitle" xml:space="preserve"><value>键盘热力图</value></data>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -51,7 +51,7 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
 
-  <data name="App_Name" xml:space="preserve"><value>按键统计</value></data>
+  <data name="App_Name" xml:space="preserve"><value>KeyStats</value></data>
   <data name="Common_Cancel" xml:space="preserve"><value>取消</value></data>
   <data name="Common_Open" xml:space="preserve"><value>打开</value></data>
   <data name="Common_Import" xml:space="preserve"><value>导入</value></data>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -62,4 +62,27 @@
   <data name="Error_AppAlreadyRunning" xml:space="preserve"><value>按键统计已在运行中。</value></data>
   <data name="Error_StartupFailedFormat" xml:space="preserve"><value>启动错误：{0}</value></data>
   <data name="Error_AppErrorTitle" xml:space="preserve"><value>按键统计错误</value></data>
+
+  <data name="Tray_OpenMainWindow" xml:space="preserve"><value>打开主界面</value></data>
+  <data name="Tray_Settings" xml:space="preserve"><value>设置</value></data>
+  <data name="Tray_StartAtLogin" xml:space="preserve"><value>开机启动</value></data>
+  <data name="Tray_KeyHistory" xml:space="preserve"><value>历史按键统计</value></data>
+  <data name="Tray_Quit" xml:space="preserve"><value>退出</value></data>
+
+  <data name="Toast_ExportSuccess_Title" xml:space="preserve"><value>导出成功</value></data>
+  <data name="Toast_ExportSuccess_BodyFormat" xml:space="preserve"><value>数据已保存到 {0}</value></data>
+  <data name="Toast_ExportFailed_Title" xml:space="preserve"><value>导出失败</value></data>
+  <data name="Toast_ExportFailed_BodyFormat" xml:space="preserve"><value>无法导出数据：{0}</value></data>
+  <data name="Toast_ImportSuccess_Title" xml:space="preserve"><value>导入成功</value></data>
+  <data name="Toast_ImportSuccess_BodyFormat" xml:space="preserve"><value>已{0}导入统计数据：{1}</value></data>
+  <data name="Toast_ImportFailed_Title" xml:space="preserve"><value>导入失败</value></data>
+  <data name="Toast_ImportFailed_BodyFormat" xml:space="preserve"><value>无法导入数据：{0}</value></data>
+  <data name="ImportMode_Overwrite" xml:space="preserve"><value>覆盖</value></data>
+  <data name="ImportMode_Merge" xml:space="preserve"><value>合并</value></data>
+
+  <data name="Shortcut_Description" xml:space="preserve"><value>按键统计</value></data>
+
+  <data name="Dialog_ExportTitle" xml:space="preserve"><value>导出数据</value></data>
+  <data name="Dialog_ImportTitle" xml:space="preserve"><value>导入数据</value></data>
+  <data name="Dialog_JsonFilter" xml:space="preserve"><value>JSON 文件 (*.json)|*.json|所有文件 (*.*)|*.*</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -62,6 +62,13 @@
   <data name="Error_AppAlreadyRunning" xml:space="preserve"><value>按键统计已在运行中。</value></data>
   <data name="Error_StartupFailedFormat" xml:space="preserve"><value>启动错误：{0}</value></data>
   <data name="Error_AppErrorTitle" xml:space="preserve"><value>按键统计错误</value></data>
+  <data name="Error_ImportInvalidFormat" xml:space="preserve"><value>数据格式无效。</value></data>
+  <data name="Error_ImportUnsupportedVersion" xml:space="preserve"><value>不支持的导出版本。</value></data>
+  <data name="Error_ImportEmpty" xml:space="preserve"><value>所选文件为空。</value></data>
+
+  <data name="Notif_ThresholdTitle" xml:space="preserve"><value>统计提醒</value></data>
+  <data name="Notif_KeyThresholdReachedFormat" xml:space="preserve"><value>今日按键数已达到 {0:N0} 次</value></data>
+  <data name="Notif_ClickThresholdReachedFormat" xml:space="preserve"><value>今日点击数已达到 {0:N0} 次</value></data>
 
   <data name="Tray_OpenMainWindow" xml:space="preserve"><value>打开主界面</value></data>
   <data name="Tray_Settings" xml:space="preserve"><value>设置</value></data>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -104,4 +104,34 @@
   <data name="Settings_DistanceCalibrationDesc" xml:space="preserve"><value>校准鼠标移动距离系数</value></data>
   <data name="Settings_VersionFormat" xml:space="preserve"><value>当前版本 {0}</value></data>
   <data name="Settings_OpenGitHubFailedMessage" xml:space="preserve"><value>无法打开 GitHub 页面。</value></data>
+
+  <data name="Stats_TodayHeader" xml:space="preserve"><value>今日统计</value></data>
+  <data name="Stats_PeakKpsLabel" xml:space="preserve"><value>峰值 KPS</value></data>
+  <data name="Stats_PeakCpsLabel" xml:space="preserve"><value>峰值 CPS</value></data>
+  <data name="Stats_KeyPresses" xml:space="preserve"><value>按键次数</value></data>
+  <data name="Stats_MouseClicks" xml:space="preserve"><value>鼠标点击</value></data>
+  <data name="Stats_MouseClickDetail" xml:space="preserve"><value>鼠标点击明细</value></data>
+  <data name="Click_Left" xml:space="preserve"><value>左键</value></data>
+  <data name="Click_Middle" xml:space="preserve"><value>中键</value></data>
+  <data name="Click_Right" xml:space="preserve"><value>右键</value></data>
+  <data name="Click_Back" xml:space="preserve"><value>后退</value></data>
+  <data name="Click_Forward" xml:space="preserve"><value>前进</value></data>
+  <data name="Stats_MouseDistance" xml:space="preserve"><value>鼠标移动</value></data>
+  <data name="Stats_ScrollDistance" xml:space="preserve"><value>滚轮滚动</value></data>
+  <data name="Stats_KeyBreakdown" xml:space="preserve"><value>按键分布</value></data>
+  <data name="Stats_KeyboardHeatmap" xml:space="preserve"><value>键盘热力图</value></data>
+  <data name="Stats_KeyHistory" xml:space="preserve"><value>历史按键统计</value></data>
+  <data name="Stats_ActiveApps" xml:space="preserve"><value>活跃应用</value></data>
+  <data name="Stats_AppStatsDetail" xml:space="preserve"><value>应用统计详情</value></data>
+  <data name="Stats_HistoryHeader" xml:space="preserve"><value>历史记录</value></data>
+  <data name="Chart_Line" xml:space="preserve"><value>折线</value></data>
+  <data name="Chart_Bar" xml:space="preserve"><value>柱状</value></data>
+  <data name="Range_7Days" xml:space="preserve"><value>7天</value></data>
+  <data name="Range_30Days" xml:space="preserve"><value>30天</value></data>
+  <data name="Metric_Clicks" xml:space="preserve"><value>点击</value></data>
+  <data name="Metric_Keys" xml:space="preserve"><value>按键</value></data>
+  <data name="Metric_Move" xml:space="preserve"><value>移动</value></data>
+  <data name="Metric_Scroll" xml:space="preserve"><value>滚动</value></data>
+  <data name="Stats_PeakKpsTooltipLabel" xml:space="preserve"><value>峰值按键速度(KPS)</value></data>
+  <data name="Stats_PeakCpsTooltipLabel" xml:space="preserve"><value>峰值点击速度(CPS)</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -103,4 +103,5 @@
   <data name="Settings_DistanceCalibration" xml:space="preserve"><value>距离校准</value></data>
   <data name="Settings_DistanceCalibrationDesc" xml:space="preserve"><value>校准鼠标移动距离系数</value></data>
   <data name="Settings_VersionFormat" xml:space="preserve"><value>当前版本 {0}</value></data>
+  <data name="Settings_OpenGitHubFailedMessage" xml:space="preserve"><value>无法打开 GitHub 页面。</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -200,4 +200,27 @@
   <data name="Calibration_ScaleLabelEmpty" xml:space="preserve"><value>换算系数: --</value></data>
   <data name="Calibration_ScaleLabelFormat" xml:space="preserve"><value>换算系数: {0:E4} m/px</value></data>
   <data name="Calibration_TipFooter" xml:space="preserve"><value>提示：如需更准确，请关闭系统鼠标加速并保持匀速移动。</value></data>
+
+  <!-- NotificationSettingsWindow -->
+  <data name="NotifSettings_WindowTitle" xml:space="preserve"><value>通知设置 - KeyStats</value></data>
+  <data name="NotifSettings_HeaderTitle" xml:space="preserve"><value>通知设置</value></data>
+  <data name="NotifSettings_HeaderSubtitle" xml:space="preserve"><value>当按键或点击次数每达到设定值时发送通知</value></data>
+  <data name="NotifSettings_Enable" xml:space="preserve"><value>启用通知</value></data>
+  <data name="NotifSettings_KeyCardTitle" xml:space="preserve"><value>按键次数通知</value></data>
+  <data name="NotifSettings_ClickCardTitle" xml:space="preserve"><value>鼠标点击通知</value></data>
+  <data name="NotifSettings_EveryPrefix" xml:space="preserve"><value>每 </value></data>
+  <data name="NotifSettings_TimesSuffix" xml:space="preserve"><value> 次通知一次</value></data>
+  <data name="NotifSettings_Hint" xml:space="preserve"><value>例如：设为 1000，则在 1000、2000、3000… 次时通知。</value></data>
+
+  <!-- ImportModeDialog -->
+  <data name="ImportDialog_HeaderTitle" xml:space="preserve"><value>选择导入方式</value></data>
+  <data name="ImportDialog_Description" xml:space="preserve"><value>请选择如何处理导入的数据：</value></data>
+  <data name="ImportDialog_OverwriteDesc" xml:space="preserve"><value>删除现有数据，使用导入的数据替换</value></data>
+  <data name="ImportDialog_MergeDesc" xml:space="preserve"><value>保留现有数据，将导入的数据累加合并</value></data>
+
+  <!-- ConfirmDialog -->
+  <data name="Confirm_DefaultHeaderTitle" xml:space="preserve"><value>确认操作</value></data>
+  <data name="Confirm_DefaultMessage" xml:space="preserve"><value>确定要执行此操作吗？</value></data>
+  <data name="Confirm_DefaultTitle" xml:space="preserve"><value>确认</value></data>
+  <data name="Confirm_DefaultConfirm" xml:space="preserve"><value>确定</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -52,10 +52,7 @@
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
 
   <data name="App_Name" xml:space="preserve"><value>按键统计</value></data>
-  <data name="Common_Ok" xml:space="preserve"><value>确定</value></data>
   <data name="Common_Cancel" xml:space="preserve"><value>取消</value></data>
-  <data name="Common_Close" xml:space="preserve"><value>关闭</value></data>
-  <data name="Common_Retry" xml:space="preserve"><value>重试</value></data>
   <data name="Common_Open" xml:space="preserve"><value>打开</value></data>
   <data name="Common_Import" xml:space="preserve"><value>导入</value></data>
   <data name="Common_Export" xml:space="preserve"><value>导出</value></data>
@@ -113,8 +110,6 @@
   <data name="Settings_OpenGitHubFailedMessage" xml:space="preserve"><value>无法打开 GitHub 页面。</value></data>
 
   <data name="Stats_TodayHeader" xml:space="preserve"><value>今日统计</value></data>
-  <data name="Stats_PeakKpsLabel" xml:space="preserve"><value>峰值 KPS</value></data>
-  <data name="Stats_PeakCpsLabel" xml:space="preserve"><value>峰值 CPS</value></data>
   <data name="Stats_KeyPresses" xml:space="preserve"><value>按键次数</value></data>
   <data name="Stats_MouseClicks" xml:space="preserve"><value>鼠标点击</value></data>
   <data name="Stats_MouseClickDetail" xml:space="preserve"><value>鼠标点击明细</value></data>
@@ -189,19 +184,8 @@
 
   <data name="Calibration_WindowTitle" xml:space="preserve"><value>鼠标距离校准</value></data>
   <data name="Calibration_HeaderTitle" xml:space="preserve"><value>鼠标距离校准</value></data>
-  <data name="Calibration_Instruction" xml:space="preserve"><value>按任意键开始记录，沿直线移动 10cm，然后再按任意键结束。</value></data>
-  <data name="Calibration_StartTitle" xml:space="preserve"><value>鼠标距离校准</value></data>
-  <data name="Calibration_StartMessage" xml:space="preserve"><value>准备一把 10cm 标尺。点击“开始”后，将鼠标放在起点，按任意键开始记录；沿直线移动 10cm 后，再按任意键结束。</value></data>
   <data name="Calibration_Start" xml:space="preserve"><value>开始</value></data>
-  <data name="Calibration_FinishTitle" xml:space="preserve"><value>正在校准</value></data>
-  <data name="Calibration_FinishMessage" xml:space="preserve"><value>请在 10cm 标尺上直线移动鼠标，完成后点击“完成”。</value></data>
   <data name="Calibration_Finish" xml:space="preserve"><value>完成</value></data>
-  <data name="Calibration_SuccessTitle" xml:space="preserve"><value>校准完成</value></data>
-  <data name="Calibration_SuccessMessageFormat" xml:space="preserve"><value>10cm &#8776; {0}，系数已更新为 {1}。</value></data>
-  <data name="Calibration_FailureTitle" xml:space="preserve"><value>校准失败</value></data>
-  <data name="Calibration_FailureMessage" xml:space="preserve"><value>移动距离过短或未检测到移动，请重试。</value></data>
-  <data name="Calibration_StatusWaiting" xml:space="preserve"><value>按任意键开始记录...</value></data>
-  <data name="Calibration_StatusMovingFormat" xml:space="preserve"><value>已移动 {0}</value></data>
 
   <data name="Calibration_InstructionEnter" xml:space="preserve"><value>按回车开始记录，再按回车结束记录并计算距离系数</value></data>
   <data name="Calibration_LengthLabel" xml:space="preserve"><value>标尺长度</value></data>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -169,8 +169,6 @@
   <data name="Heatmap_NoData" xml:space="preserve"><value>当天暂无键盘活动</value></data>
   <data name="Heatmap_SummaryFormat" xml:space="preserve"><value>总计 {0} 次按键 · {1} 个活跃键</value></data>
   <data name="Heatmap_DatePickerTooltip" xml:space="preserve"><value>选择日期</value></data>
-  <data name="Heatmap_DateFormatShort" xml:space="preserve"><value>{0}月{1}日</value></data>
-  <data name="Heatmap_DateFormatLong" xml:space="preserve"><value>{0}年{1}月{2}日</value></data>
 
   <data name="KeyHistory_WindowTitle" xml:space="preserve"><value>历史按键统计</value></data>
   <data name="KeyHistory_HeaderTitle" xml:space="preserve"><value>历史按键统计</value></data>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -165,4 +165,39 @@
   <data name="History_Range_Last7Days" xml:space="preserve"><value>过去7天</value></data>
   <data name="History_Range_Last30Days" xml:space="preserve"><value>过去30天</value></data>
   <data name="History_Range_All" xml:space="preserve"><value>全部</value></data>
+
+  <data name="Calibration_WindowTitle" xml:space="preserve"><value>鼠标距离校准</value></data>
+  <data name="Calibration_HeaderTitle" xml:space="preserve"><value>鼠标距离校准</value></data>
+  <data name="Calibration_Instruction" xml:space="preserve"><value>按任意键开始记录，沿直线移动 10cm，然后再按任意键结束。</value></data>
+  <data name="Calibration_StartTitle" xml:space="preserve"><value>鼠标距离校准</value></data>
+  <data name="Calibration_StartMessage" xml:space="preserve"><value>准备一把 10cm 标尺。点击“开始”后，将鼠标放在起点，按任意键开始记录；沿直线移动 10cm 后，再按任意键结束。</value></data>
+  <data name="Calibration_Start" xml:space="preserve"><value>开始</value></data>
+  <data name="Calibration_FinishTitle" xml:space="preserve"><value>正在校准</value></data>
+  <data name="Calibration_FinishMessage" xml:space="preserve"><value>请在 10cm 标尺上直线移动鼠标，完成后点击“完成”。</value></data>
+  <data name="Calibration_Finish" xml:space="preserve"><value>完成</value></data>
+  <data name="Calibration_SuccessTitle" xml:space="preserve"><value>校准完成</value></data>
+  <data name="Calibration_SuccessMessageFormat" xml:space="preserve"><value>10cm &#8776; {0}，系数已更新为 {1}。</value></data>
+  <data name="Calibration_FailureTitle" xml:space="preserve"><value>校准失败</value></data>
+  <data name="Calibration_FailureMessage" xml:space="preserve"><value>移动距离过短或未检测到移动，请重试。</value></data>
+  <data name="Calibration_StatusWaiting" xml:space="preserve"><value>按任意键开始记录...</value></data>
+  <data name="Calibration_StatusMovingFormat" xml:space="preserve"><value>已移动 {0}</value></data>
+
+  <data name="Calibration_InstructionEnter" xml:space="preserve"><value>按回车开始记录，再按回车结束记录并计算距离系数</value></data>
+  <data name="Calibration_LengthLabel" xml:space="preserve"><value>标尺长度</value></data>
+  <data name="Calibration_StepsLabel" xml:space="preserve"><value>校准步骤</value></data>
+  <data name="Calibration_StatusIdle" xml:space="preserve"><value>未开始，按回车开始</value></data>
+  <data name="Calibration_StatusRecording" xml:space="preserve"><value>已开始，移动标尺长度后按回车结束</value></data>
+  <data name="Calibration_StatusPressEnterFirst" xml:space="preserve"><value>请先按回车开始</value></data>
+  <data name="Calibration_StatusMovementTooShort" xml:space="preserve"><value>移动距离过短，请重新校准</value></data>
+  <data name="Calibration_StatusInvalidLength" xml:space="preserve"><value>标尺长度无效</value></data>
+  <data name="Calibration_StatusComplete" xml:space="preserve"><value>校准完成</value></data>
+  <data name="Calibration_DisplayUnitLabel" xml:space="preserve"><value>显示单位</value></data>
+  <data name="Calibration_UnitAuto" xml:space="preserve"><value>自动 (cm/m/km)</value></data>
+  <data name="Calibration_UnitPixel" xml:space="preserve"><value>像素 (px)</value></data>
+  <data name="Calibration_CurrentResultLabel" xml:space="preserve"><value>当前结果</value></data>
+  <data name="Calibration_PixelsLabelEmpty" xml:space="preserve"><value>像素距离: --</value></data>
+  <data name="Calibration_PixelsLabelFormat" xml:space="preserve"><value>像素距离: {0:F0} px</value></data>
+  <data name="Calibration_ScaleLabelEmpty" xml:space="preserve"><value>换算系数: --</value></data>
+  <data name="Calibration_ScaleLabelFormat" xml:space="preserve"><value>换算系数: {0:E4} m/px</value></data>
+  <data name="Calibration_TipFooter" xml:space="preserve"><value>提示：如需更准确，请关闭系统鼠标加速并保持匀速移动。</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -143,4 +143,16 @@
   <data name="AppStats_Range30Days" xml:space="preserve"><value>过去30天</value></data>
   <data name="AppStats_RangeAll" xml:space="preserve"><value>全部</value></data>
   <data name="AppStats_ColumnApp" xml:space="preserve"><value>应用</value></data>
+
+  <data name="Heatmap_WindowTitle" xml:space="preserve"><value>键盘热力图</value></data>
+  <data name="Heatmap_HeaderTitle" xml:space="preserve"><value>键盘热力图</value></data>
+  <data name="Heatmap_HeaderSubtitle" xml:space="preserve"><value>完整虚拟键盘视图，按天展示按键热度。</value></data>
+  <data name="Heatmap_PrevDay" xml:space="preserve"><value>上一天</value></data>
+  <data name="Heatmap_NextDay" xml:space="preserve"><value>下一天</value></data>
+  <data name="Heatmap_BackToToday" xml:space="preserve"><value>回到今天</value></data>
+  <data name="Heatmap_NoData" xml:space="preserve"><value>当天暂无键盘活动</value></data>
+  <data name="Heatmap_SummaryFormat" xml:space="preserve"><value>总计 {0} 次按键 · {1} 个活跃键</value></data>
+  <data name="Heatmap_DatePickerTooltip" xml:space="preserve"><value>选择日期</value></data>
+  <data name="Heatmap_DateFormatShort" xml:space="preserve"><value>{0}月{1}日</value></data>
+  <data name="Heatmap_DateFormatLong" xml:space="preserve"><value>{0}年{1}月{2}日</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -119,6 +119,7 @@
   <data name="Stats_MouseDistance" xml:space="preserve"><value>鼠标移动</value></data>
   <data name="Stats_ScrollDistance" xml:space="preserve"><value>滚轮滚动</value></data>
   <data name="Stats_KeyBreakdown" xml:space="preserve"><value>按键分布</value></data>
+  <data name="KeyBreakdown_Empty" xml:space="preserve"><value>暂无按键记录</value></data>
   <data name="Stats_KeyboardHeatmap" xml:space="preserve"><value>键盘热力图</value></data>
   <data name="Stats_KeyHistory" xml:space="preserve"><value>历史按键统计</value></data>
   <data name="Stats_ActiveApps" xml:space="preserve"><value>活跃应用</value></data>
@@ -153,6 +154,9 @@
   <data name="History_TotalFormat" xml:space="preserve"><value>总计: {0}</value></data>
   <data name="KeyHistory_Empty" xml:space="preserve"><value>暂无历史按键数据</value></data>
   <data name="KeyHistory_SummaryFormat" xml:space="preserve"><value>总按键: {0} · 按键种类: {1}</value></data>
+  <data name="PieChart_Empty" xml:space="preserve"><value>暂无数据</value></data>
+  <data name="PieChart_CountFormat" xml:space="preserve"><value>次数: {0}</value></data>
+  <data name="PieChart_PercentFormat" xml:space="preserve"><value>比例: {0}</value></data>
 
   <data name="Heatmap_WindowTitle" xml:space="preserve"><value>键盘热力图</value></data>
   <data name="Heatmap_HeaderTitle" xml:space="preserve"><value>键盘热力图</value></data>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -85,4 +85,10 @@
   <data name="Dialog_ExportTitle" xml:space="preserve"><value>导出数据</value></data>
   <data name="Dialog_ImportTitle" xml:space="preserve"><value>导入数据</value></data>
   <data name="Dialog_JsonFilter" xml:space="preserve"><value>JSON 文件 (*.json)|*.json|所有文件 (*.*)|*.*</value></data>
+
+  <data name="Settings_Language" xml:space="preserve"><value>语言</value></data>
+  <data name="Settings_LanguageDescription" xml:space="preserve"><value>应用界面显示语言</value></data>
+  <data name="Settings_Language_System" xml:space="preserve"><value>跟随系统</value></data>
+  <data name="Language_RestartPromptTitle" xml:space="preserve"><value>需要重启</value></data>
+  <data name="Language_RestartPromptMessage" xml:space="preserve"><value>需要重启 KeyStats 才能切换语言。是否立即重启？</value></data>
 </root>

--- a/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
+++ b/KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+
+  <data name="App_Name" xml:space="preserve"><value>按键统计</value></data>
+  <data name="Common_Ok" xml:space="preserve"><value>确定</value></data>
+  <data name="Common_Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="Common_Close" xml:space="preserve"><value>关闭</value></data>
+  <data name="Common_Retry" xml:space="preserve"><value>重试</value></data>
+  <data name="Common_Open" xml:space="preserve"><value>打开</value></data>
+  <data name="Common_Import" xml:space="preserve"><value>导入</value></data>
+  <data name="Common_Export" xml:space="preserve"><value>导出</value></data>
+  <data name="Error_AppAlreadyRunning" xml:space="preserve"><value>按键统计已在运行中。</value></data>
+  <data name="Error_StartupFailedFormat" xml:space="preserve"><value>启动错误：{0}</value></data>
+  <data name="Error_AppErrorTitle" xml:space="preserve"><value>按键统计错误</value></data>
+</root>

--- a/KeyStats.Windows/KeyStats/Services/InputMonitorService.cs
+++ b/KeyStats.Windows/KeyStats/Services/InputMonitorService.cs
@@ -19,17 +19,17 @@ public class InputMonitorService : IDisposable
     private NativeInterop.LowLevelMouseProc? _mouseProc;
 
     private bool _isMonitoring;
-    private readonly HashSet<int> _pressedKeys = new(); // 跟踪当前按下的键，防止长按时重复计数
+    private readonly HashSet<int> _pressedKeys = new(); // Tracks currently held keys to avoid double-counting on key repeats.
     private readonly double _mouseSampleInterval = 1.0 / 30.0; // 30 FPS
     private DateTime _lastMouseSampleTime = DateTime.MinValue;
     private System.Drawing.Point? _lastMousePosition;
     private double _accumulatedDistance = 0.0;
 
-    // 专用 hook 线程，避免 UI 线程卡顿导致 hook 超时
+    // Dedicated hook thread so UI-thread stalls cannot cause hook callback timeouts.
     private Thread? _hookThread;
     private uint _hookThreadId;
 
-    // hook 健康检查：watchdog 定时检测 hook 是否被 Windows 静默移除
+    // Hook health watchdog: detects whether Windows has silently removed our hooks.
     private Timer? _watchdogTimer;
     private int _lastHookCallbackTick;
     private int _isReinstallingHooks;
@@ -65,7 +65,7 @@ public class InputMonitorService : IDisposable
 
         _isMonitoring = true;
 
-        // 启动 watchdog 定时检测 hook 是否存活
+        // Start the watchdog timer that periodically checks whether the hooks are still alive.
         _watchdogTimer = new Timer(WatchdogCallback, null, WatchdogIntervalMs, WatchdogIntervalMs);
 
         Debug.WriteLine("Input monitoring started successfully (dedicated hook thread)");
@@ -193,7 +193,7 @@ public class InputMonitorService : IDisposable
 
         if (!cursorMoved && !keyboardActivity) return;
 
-        // 光标在移动，但 hook 回调长时间未被触发 → hook 可能已被 Windows 静默移除
+        // The cursor is moving but no hook callback has fired in a while → Windows likely removed the hooks silently.
         var elapsed = unchecked((uint)(Environment.TickCount - Volatile.Read(ref _lastHookCallbackTick)));
         if (elapsed > HookDeadThresholdMs)
         {
@@ -225,7 +225,7 @@ public class InputMonitorService : IDisposable
         _watchdogTimer?.Dispose();
         _watchdogTimer = null;
 
-        // 终止 hook 线程的消息循环
+        // Terminate the hook thread's message loop.
         if (!TryStopHookThread())
         {
             Debug.WriteLine("Failed to stop the hook thread within the timeout. Continuing shutdown cleanup.");

--- a/KeyStats.Windows/KeyStats/Services/NotificationService.cs
+++ b/KeyStats.Windows/KeyStats/Services/NotificationService.cs
@@ -18,18 +18,17 @@ public class NotificationService
 
     public void SendThresholdNotification(Metric metric, int count)
     {
-        var formattedCount = count.ToString("N0");
         var body = metric switch
         {
-            Metric.KeyPresses => $"今日按键次数已达到 {formattedCount}！",
-            Metric.Clicks => $"今日点击次数已达到 {formattedCount}！",
+            Metric.KeyPresses => string.Format(KeyStats.Properties.Strings.Notif_KeyThresholdReachedFormat, count),
+            Metric.Clicks => string.Format(KeyStats.Properties.Strings.Notif_ClickThresholdReachedFormat, count),
             _ => ""
         };
 
         try
         {
             new ToastContentBuilder()
-                .AddText("按键统计")
+                .AddText(KeyStats.Properties.Strings.Notif_ThresholdTitle)
                 .AddText(body)
                 .Show();
         }

--- a/KeyStats.Windows/KeyStats/Services/StatsManager.cs
+++ b/KeyStats.Windows/KeyStats/Services/StatsManager.cs
@@ -491,7 +491,7 @@ public class StatsManager : IDisposable
     private void RecordCurrentStatsToHistory()
     {
         var key = CurrentStats.Date.ToString("yyyy-MM-dd");
-        // 创建 CurrentStats 的副本，避免引用共享导致的数据丢失
+        // Clone CurrentStats so callers cannot mutate the snapshot stored in History.
         var statsCopy = new DailyStats(CurrentStats.Date)
         {
             KeyPresses = CurrentStats.KeyPresses,
@@ -687,7 +687,7 @@ public class StatsManager : IDisposable
     {
         if (data == null || data.Length == 0)
         {
-            throw new InvalidDataException("导入文件为空。");
+            throw new InvalidDataException(KeyStats.Properties.Strings.Error_ImportEmpty);
         }
 
         var deserializeOptions = new JsonSerializerOptions
@@ -699,7 +699,7 @@ public class StatsManager : IDisposable
         try
         {
             payload = JsonSerializer.Deserialize<ExportPayload>(data, deserializeOptions)
-                ?? throw new InvalidDataException("数据格式无效。");
+                ?? throw new InvalidDataException(KeyStats.Properties.Strings.Error_ImportInvalidFormat);
         }
         catch (InvalidDataException)
         {
@@ -707,12 +707,12 @@ public class StatsManager : IDisposable
         }
         catch (Exception ex)
         {
-            throw new InvalidDataException("数据格式无效。", ex);
+            throw new InvalidDataException(KeyStats.Properties.Strings.Error_ImportInvalidFormat, ex);
         }
 
         if (payload.Version != 1)
         {
-            throw new InvalidDataException("不支持的导出版本。");
+            throw new InvalidDataException(KeyStats.Properties.Strings.Error_ImportUnsupportedVersion);
         }
 
         lock (_lock)
@@ -1013,10 +1013,10 @@ public class StatsManager : IDisposable
     {
         lock (_lock)
         {
-            // 先保存旧数据到 History，避免丢失最后一次保存后的增量
+            // Archive the old counters to History first so the increment since the last save isn't lost.
             RecordCurrentStatsToHistory();
 
-            // 然后创建新的统计对象
+            // Then create a fresh stats object for the new day.
             CurrentStats = new DailyStats(date);
         }
 
@@ -1102,11 +1102,11 @@ public class StatsManager : IDisposable
         var threshold = Settings.KeyPressNotifyThreshold;
         if (threshold <= 0) return;
         var count = CurrentStats.KeyPresses;
-        
-        // 计算当前计数对应的阈值里程碑（向下取整到最近的阈值倍数）
+
+        // Compute the threshold milestone for the current count (rounded down to the nearest multiple of threshold).
         var currentThreshold = NormalizedBaseline(count, threshold);
-        
-        // 如果当前阈值里程碑大于上次通知的阈值里程碑，则发送通知
+
+        // Fire a notification only when we've crossed into a new milestone since the last one.
         if (currentThreshold > _lastNotifiedKeyPresses)
         {
             _lastNotifiedKeyPresses = currentThreshold;
@@ -1120,11 +1120,11 @@ public class StatsManager : IDisposable
         var threshold = Settings.ClickNotifyThreshold;
         if (threshold <= 0) return;
         var count = CurrentStats.TotalClicks;
-        
-        // 计算当前计数对应的阈值里程碑（向下取整到最近的阈值倍数）
+
+        // Compute the threshold milestone for the current count (rounded down to the nearest multiple of threshold).
         var currentThreshold = NormalizedBaseline(count, threshold);
-        
-        // 如果当前阈值里程碑大于上次通知的阈值里程碑，则发送通知
+
+        // Fire a notification only when we've crossed into a new milestone since the last one.
         if (currentThreshold > _lastNotifiedClicks)
         {
             _lastNotifiedClicks = currentThreshold;

--- a/KeyStats.Windows/KeyStats/ViewModels/AppStatsViewModel.cs
+++ b/KeyStats.Windows/KeyStats/ViewModels/AppStatsViewModel.cs
@@ -144,11 +144,11 @@ public class AppStatsViewModel : ViewModelBase
         ScrollHeader = BuildHeader(KeyStats.Properties.Strings.AppStats_ColumnScroll, SortMetric.Scroll);
     }
 
+    private const string SortIndicator = "↓"; // ↓ — direction-only glyph, not localized
+
     private string BuildHeader(string baseText, SortMetric metric)
     {
-        return _sortMetric == metric
-            ? $"{baseText} {KeyStats.Properties.Strings.AppStats_SortIndicator}"
-            : baseText;
+        return _sortMetric == metric ? $"{baseText} {SortIndicator}" : baseText;
     }
 
     private void RefreshData()

--- a/KeyStats.Windows/KeyStats/ViewModels/AppStatsViewModel.cs
+++ b/KeyStats.Windows/KeyStats/ViewModels/AppStatsViewModel.cs
@@ -43,10 +43,10 @@ public class AppStatsViewModel : ViewModelBase
     private string _summaryText = "";
     private bool _hasData;
     private bool _isEmpty = true;
-    private string _emptyText = "暂无应用数据";
-    private string _keysHeader = "键盘";
-    private string _clicksHeader = "点击";
-    private string _scrollHeader = "滚轮";
+    private string _emptyText = KeyStats.Properties.Strings.AppStats_Empty;
+    private string _keysHeader = KeyStats.Properties.Strings.AppStats_ColumnKeys;
+    private string _clicksHeader = KeyStats.Properties.Strings.AppStats_ColumnClicks;
+    private string _scrollHeader = KeyStats.Properties.Strings.AppStats_ColumnScroll;
 
     public ObservableCollection<AppStatsRowItem> AppStatsItems { get; } = new();
 
@@ -139,14 +139,16 @@ public class AppStatsViewModel : ViewModelBase
 
     private void RefreshHeaders()
     {
-        KeysHeader = BuildHeader("键盘", SortMetric.Keys);
-        ClicksHeader = BuildHeader("点击", SortMetric.Clicks);
-        ScrollHeader = BuildHeader("滚轮", SortMetric.Scroll);
+        KeysHeader = BuildHeader(KeyStats.Properties.Strings.AppStats_ColumnKeys, SortMetric.Keys);
+        ClicksHeader = BuildHeader(KeyStats.Properties.Strings.AppStats_ColumnClicks, SortMetric.Clicks);
+        ScrollHeader = BuildHeader(KeyStats.Properties.Strings.AppStats_ColumnScroll, SortMetric.Scroll);
     }
 
     private string BuildHeader(string baseText, SortMetric metric)
     {
-        return _sortMetric == metric ? $"{baseText} ↓" : baseText;
+        return _sortMetric == metric
+            ? $"{baseText} {KeyStats.Properties.Strings.AppStats_SortIndicator}"
+            : baseText;
     }
 
     private void RefreshData()
@@ -211,9 +213,11 @@ public class AppStatsViewModel : ViewModelBase
 
         SummaryText = items.Count == 0
             ? ""
-            : $"总计: {manager.FormatHistoryValue(StatsManager.HistoryMetric.KeyPresses, totalKeys)} 键盘 | " +
-              $"{manager.FormatHistoryValue(StatsManager.HistoryMetric.Clicks, totalClicks)} 点击 | " +
-              $"{manager.FormatHistoryValue(StatsManager.HistoryMetric.ScrollDistance, totalScroll)} 滚动";
+            : string.Format(
+                KeyStats.Properties.Strings.AppStats_SummaryFormat,
+                manager.FormatHistoryValue(StatsManager.HistoryMetric.KeyPresses, totalKeys),
+                manager.FormatHistoryValue(StatsManager.HistoryMetric.Clicks, totalClicks),
+                manager.FormatHistoryValue(StatsManager.HistoryMetric.ScrollDistance, totalScroll));
 
         IsEmpty = AppStatsItems.Count == 0;
         HasData = !IsEmpty;
@@ -229,7 +233,7 @@ public class AppStatsViewModel : ViewModelBase
         {
             return stats.AppName;
         }
-        return "未知应用";
+        return KeyStats.Properties.Strings.AppStats_UnknownApp;
     }
 
     private double SortValue(AppStats stats)

--- a/KeyStats.Windows/KeyStats/ViewModels/KeyHistoryViewModel.cs
+++ b/KeyStats.Windows/KeyStats/ViewModels/KeyHistoryViewModel.cs
@@ -40,7 +40,7 @@ public class KeyHistoryViewModel : ViewModelBase
     private string _summaryText = string.Empty;
     private bool _hasData;
     private bool _isEmpty = true;
-    private string _emptyText = "暂无历史按键数据";
+    private string _emptyText = KeyStats.Properties.Strings.KeyHistory_Empty;
 
     public ObservableCollection<KeyHistoryChartItem> PieChartItems { get; } = new();
     public ObservableCollection<KeyHistoryChartItem> BarChartItems { get; } = new();
@@ -128,7 +128,10 @@ public class KeyHistoryViewModel : ViewModelBase
 
         IsEmpty = false;
         HasData = true;
-        SummaryText = $"总按键: {manager.FormatNumber(total)} · 按键种类: {manager.FormatNumber(distinct)}";
+        SummaryText = string.Format(
+            KeyStats.Properties.Strings.KeyHistory_SummaryFormat,
+            manager.FormatNumber(total),
+            manager.FormatNumber(distinct));
 
         var topForBar = allItems.Take(20).ToList();
         var maxCount = Math.Max(1, topForBar.Select(x => x.Count).DefaultIfEmpty(0).Max());

--- a/KeyStats.Windows/KeyStats/ViewModels/StatsPopupViewModel.cs
+++ b/KeyStats.Windows/KeyStats/ViewModels/StatsPopupViewModel.cs
@@ -51,7 +51,7 @@ public class StatsPopupViewModel : ViewModelBase
     private int _selectedRangeIndex;
     private int _selectedMetricIndex;
     private int _selectedChartStyleIndex;
-    private string _historySummary = "总计: 0";
+    private string _historySummary = string.Format(KeyStats.Properties.Strings.History_TotalFormat, "0");
     private ObservableCollection<ChartDataPoint> _chartData = new();
 
     public string KeyPresses
@@ -343,7 +343,7 @@ public class StatsPopupViewModel : ViewModelBase
 
         var total = series.Sum(x => x.Value);
         var formatted = StatsManager.Instance.FormatHistoryValue(metric, total);
-        HistorySummary = $"总计: {formatted}";
+        HistorySummary = string.Format(KeyStats.Properties.Strings.History_TotalFormat, formatted);
     }
 
     private void Quit()

--- a/KeyStats.Windows/KeyStats/Views/AppStatsWindow.xaml
+++ b/KeyStats.Windows/KeyStats/Views/AppStatsWindow.xaml
@@ -2,7 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:viewmodels="clr-namespace:KeyStats.ViewModels"
-        Title="按应用统计"
+        xmlns:p="clr-namespace:KeyStats.Properties"
+        Title="{x:Static p:Strings.AppStats_WindowTitle}"
         Width="720"
         Height="640"
         MinWidth="640"
@@ -26,9 +27,9 @@
 
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,10">
-            <TextBlock Text="按应用统计" FontSize="20" FontWeight="SemiBold"
+            <TextBlock Text="{x:Static p:Strings.AppStats_HeaderTitle}" FontSize="20" FontWeight="SemiBold"
                        Foreground="{DynamicResource TextPrimaryBrush}"/>
-            <TextBlock Text="按应用统计键盘/点击/滚动，仅保存聚合数据"
+            <TextBlock Text="{x:Static p:Strings.AppStats_HeaderSubtitle}"
                        FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}"
                        TextWrapping="Wrap" Margin="0,4,0,0"/>
         </StackPanel>
@@ -36,16 +37,16 @@
         <!-- Range -->
         <Border Grid.Row="1" Background="{DynamicResource SubtleFillBrush}" CornerRadius="6" Padding="3" Margin="0,0,0,10">
             <StackPanel Orientation="Horizontal">
-                <RadioButton Content="今天" GroupName="AppStatsRange"
+                <RadioButton Content="{x:Static p:Strings.AppStats_RangeToday}" GroupName="AppStatsRange"
                              Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="10,4"
                              IsChecked="{Binding SelectedRangeIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=0}"/>
-                <RadioButton Content="过去7天" GroupName="AppStatsRange"
+                <RadioButton Content="{x:Static p:Strings.AppStats_Range7Days}" GroupName="AppStatsRange"
                              Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="10,4"
                              IsChecked="{Binding SelectedRangeIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=1}"/>
-                <RadioButton Content="过去30天" GroupName="AppStatsRange"
+                <RadioButton Content="{x:Static p:Strings.AppStats_Range30Days}" GroupName="AppStatsRange"
                              Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="10,4"
                              IsChecked="{Binding SelectedRangeIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=2}"/>
-                <RadioButton Content="全部" GroupName="AppStatsRange"
+                <RadioButton Content="{x:Static p:Strings.AppStats_RangeAll}" GroupName="AppStatsRange"
                              Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="10,4"
                              IsChecked="{Binding SelectedRangeIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=3}"/>
             </StackPanel>
@@ -65,7 +66,7 @@
                 <ColumnDefinition Width="120"/>
                 <ColumnDefinition Width="120"/>
             </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Text="应用" FontSize="12" FontWeight="SemiBold"
+            <TextBlock Grid.Column="0" Text="{x:Static p:Strings.AppStats_ColumnApp}" FontSize="12" FontWeight="SemiBold"
                        Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center"/>
             <Button Grid.Column="1" Content="{Binding KeysHeader}" Style="{DynamicResource AppStatsHeaderButton}"
                     Command="{Binding SortCommand}" CommandParameter="Keys"/>

--- a/KeyStats.Windows/KeyStats/Views/ConfirmDialog.xaml
+++ b/KeyStats.Windows/KeyStats/Views/ConfirmDialog.xaml
@@ -1,6 +1,7 @@
 <Window x:Class="KeyStats.Views.ConfirmDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:p="clr-namespace:KeyStats.Properties"
         Title=""
         Width="400" SizeToContent="Height"
         WindowStartupLocation="CenterScreen"
@@ -38,7 +39,7 @@
                 </Border>
 
                 <!-- Title -->
-                <TextBlock x:Name="TitleText" Text="确认操作"
+                <TextBlock x:Name="TitleText" Text="{x:Static p:Strings.Confirm_DefaultHeaderTitle}"
                            FontSize="18" FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimaryBrush}"
                            TextWrapping="Wrap"/>
@@ -46,7 +47,7 @@
 
             <!-- Message -->
             <TextBlock x:Name="MessageText" Grid.Row="1"
-                       Text="确定要执行此操作吗？"
+                       Text="{x:Static p:Strings.Confirm_DefaultMessage}"
                        FontSize="14" LineHeight="22"
                        Foreground="{DynamicResource TextSecondaryBrush}"
                        TextWrapping="Wrap"
@@ -56,14 +57,14 @@
             <StackPanel Grid.Row="2" Orientation="Horizontal"
                         HorizontalAlignment="Right" Margin="24,24,24,24">
                 <!-- Cancel Button -->
-                <Button x:Name="CancelButton" Content="取消"
+                <Button x:Name="CancelButton" Content="{x:Static p:Strings.Common_Cancel}"
                         Click="CancelButton_Click"
                         Style="{StaticResource GhostButton}"
                         MinWidth="88" Height="32"
                         Margin="0,0,8,0"/>
 
                 <!-- Confirm Button -->
-                <Button x:Name="ConfirmButton" Content="确定"
+                <Button x:Name="ConfirmButton" Content="{x:Static p:Strings.Confirm_DefaultConfirm}"
                         Click="ConfirmButton_Click"
                         MinWidth="88" Height="32">
                     <Button.Style>

--- a/KeyStats.Windows/KeyStats/Views/ConfirmDialog.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/ConfirmDialog.xaml.cs
@@ -65,17 +65,17 @@ namespace KeyStats.Views
 
         public static bool Show(
             string message,
-            string title = "确认",
-            string confirmText = "确定",
-            string cancelText = "取消",
+            string? title = null,
+            string? confirmText = null,
+            string? cancelText = null,
             DialogIcon icon = DialogIcon.Warning,
             Window? owner = null)
         {
             var dialog = new ConfirmDialog();
-            dialog.TitleText.Text = title;
+            dialog.TitleText.Text = title ?? KeyStats.Properties.Strings.Confirm_DefaultTitle;
             dialog.MessageText.Text = message;
-            dialog.ConfirmButton.Content = confirmText;
-            dialog.CancelButton.Content = cancelText;
+            dialog.ConfirmButton.Content = confirmText ?? KeyStats.Properties.Strings.Confirm_DefaultConfirm;
+            dialog.CancelButton.Content = cancelText ?? KeyStats.Properties.Strings.Common_Cancel;
             dialog.SetIcon(icon);
 
             if (owner != null)

--- a/KeyStats.Windows/KeyStats/Views/Controls/KeyBreakdownControl.xaml
+++ b/KeyStats.Windows/KeyStats/Views/Controls/KeyBreakdownControl.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:viewmodels="clr-namespace:KeyStats.ViewModels"
+             xmlns:p="clr-namespace:KeyStats.Properties"
              MinHeight="24">
     <Grid>
         <Grid.ColumnDefinitions>
@@ -95,7 +96,7 @@
 
         <!-- Empty State -->
         <TextBlock x:Name="EmptyText" Grid.ColumnSpan="5"
-                   Text="暂无按键记录"
+                   Text="{x:Static p:Strings.KeyBreakdown_Empty}"
                    HorizontalAlignment="Center" VerticalAlignment="Center"
                    FontSize="12"
                    Foreground="{DynamicResource TextTertiaryBrush}"

--- a/KeyStats.Windows/KeyStats/Views/Controls/KeyDistributionPieChartControl.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/Controls/KeyDistributionPieChartControl.xaml.cs
@@ -112,8 +112,8 @@ public partial class KeyDistributionPieChartControl : UserControl
     private void ShowCenterContent(KeyHistoryChartItem item)
     {
         CenterKeyText.Text = item.Key;
-        CenterCountText.Text = $"次数: {item.CountText}";
-        CenterPercentText.Text = $"比例: {item.PercentageText}";
+        CenterCountText.Text = string.Format(KeyStats.Properties.Strings.PieChart_CountFormat, item.CountText);
+        CenterPercentText.Text = string.Format(KeyStats.Properties.Strings.PieChart_PercentFormat, item.PercentageText);
     }
 
     private void ResetCenterContent()
@@ -177,13 +177,13 @@ public partial class KeyDistributionPieChartControl : UserControl
 
     private void DrawEmptyState()
     {
-        CenterKeyText.Text = "暂无数据";
+        CenterKeyText.Text = KeyStats.Properties.Strings.PieChart_Empty;
         CenterCountText.Text = string.Empty;
         CenterPercentText.Text = string.Empty;
 
         var text = new TextBlock
         {
-            Text = "暂无数据",
+            Text = KeyStats.Properties.Strings.PieChart_Empty,
             FontSize = 12,
             Foreground = Application.Current?.Resources["TextSecondaryBrush"] as Brush ?? Brushes.Gray
         };

--- a/KeyStats.Windows/KeyStats/Views/Controls/StatsChartControl.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/Controls/StatsChartControl.xaml.cs
@@ -53,15 +53,15 @@ public partial class StatsChartControl : System.Windows.Controls.UserControl
     private SolidColorBrush _textBrush = new(SystemColors.GrayTextColor);
     private SolidColorBrush _highlightBrush = new(Color.FromRgb(255, 100, 50));
 
-    // 存储数据点位置信息，用于鼠标悬停检测
+    // Stores data point positions for mouse hover hit-testing
     private List<PointData> _dataPoints = new();
 
-    // 悬停标签（使用 Border 包裹以遮挡静态标签）
+    // Hover labels (wrapped in Border to occlude the static axis labels)
     private Border? _hoverYContainer;
     private Border? _hoverXContainer;
     private SolidColorBrush _hoverBgBrush = new(Color.FromArgb(230, 248, 248, 248));
-    
-    // 绘图区域参数（用于 hover 检测）
+
+    // Plot area parameters (used for hover hit-testing)
     private double _plotLeft;
     private double _plotTop;
     private double _plotWidth;
@@ -73,7 +73,7 @@ public partial class StatsChartControl : System.Windows.Controls.UserControl
         UpdateBrushesFromTheme();
         SizeChanged += OnSizeChanged;
 
-        // 添加鼠标移动事件处理
+        // Wire up mouse move handlers for hover detection
         ChartCanvas.MouseMove += OnCanvasMouseMove;
         ChartCanvas.MouseLeave += OnCanvasMouseLeave;
 
@@ -121,13 +121,13 @@ public partial class StatsChartControl : System.Windows.Controls.UserControl
     {
         if (d is StatsChartControl control)
         {
-            // 取消订阅旧集合的变化事件
+            // Unsubscribe from the old collection's change events
             if (e.OldValue is INotifyCollectionChanged oldCollection)
             {
                 oldCollection.CollectionChanged -= control.OnChartDataCollectionChanged;
             }
 
-            // 订阅新集合的变化事件
+            // Subscribe to the new collection's change events
             if (e.NewValue is INotifyCollectionChanged newCollection)
             {
                 newCollection.CollectionChanged += control.OnChartDataCollectionChanged;
@@ -139,7 +139,7 @@ public partial class StatsChartControl : System.Windows.Controls.UserControl
 
     private void OnChartDataCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        // 当集合内容变化时，重新绘制图表
+        // Redraw the chart when the underlying collection changes
         DrawChart();
     }
 
@@ -340,8 +340,8 @@ public partial class StatsChartControl : System.Windows.Controls.UserControl
             var point = new Point(x, y);
             points.Add(point);
             pointList.Add(point);
-            
-            // 存储数据点信息
+
+            // Record the data point for later hover hit-testing
             _dataPoints.Add(new PointData
             {
                 DataPoint = data[i],
@@ -397,8 +397,8 @@ public partial class StatsChartControl : System.Windows.Controls.UserControl
             Canvas.SetLeft(bar, x);
             Canvas.SetTop(bar, y);
             ChartCanvas.Children.Add(bar);
-            
-            // 存储数据点信息（柱状图的中心位置）
+
+            // Record the data point at the bar center for hover hit-testing
             var centerX = x + barWidth / 2;
             var centerY = y;
             _dataPoints.Add(new PointData
@@ -422,7 +422,7 @@ public partial class StatsChartControl : System.Windows.Controls.UserControl
 
     private string FormatValue(double value)
     {
-        // 根据当前选择的指标类型使用不同的格式化方法
+        // Pick the formatter that matches the currently selected metric
         var metric = SelectedMetricIndex switch
         {
             0 => StatsManager.HistoryMetric.Clicks,
@@ -438,16 +438,16 @@ public partial class StatsChartControl : System.Windows.Controls.UserControl
     private void OnCanvasMouseMove(object sender, System.Windows.Input.MouseEventArgs e)
     {
         var position = e.GetPosition(ChartCanvas);
-        
-        // 只在实际绘图区域内检测
+
+        // Only hit-test inside the actual plot area
         if (position.X < _plotLeft || position.X > _plotLeft + _plotWidth ||
             position.Y < _plotTop || position.Y > _plotTop + _plotHeight)
         {
             HideHoverLabels();
             return;
         }
-        
-        // 只按 X 轴距离查找最近的数据点（鼠标在绘图区域内任意高度都能触发）
+
+        // Find the nearest data point by X distance only (any Y inside the plot area triggers hover)
         PointData? closestPoint = null;
         double minDistanceX = double.MaxValue;
 
@@ -483,13 +483,13 @@ public partial class StatsChartControl : System.Windows.Controls.UserControl
     {
         var plotBottom = _plotTop + _plotHeight;
 
-        // 移除旧的标签
+        // Remove the previous hover labels
         if (_hoverYContainer != null)
             ChartCanvas.Children.Remove(_hoverYContainer);
         if (_hoverXContainer != null)
             ChartCanvas.Children.Remove(_hoverXContainer);
 
-        // 创建 Y 轴标签（显示数值），带背景遮挡静态标签
+        // Build the Y-axis hover label (value) with a background that covers the static label
         var yLabel = CreateLabel(FormatValue(pointData.DataPoint.Value), _highlightBrush, 10);
         yLabel.FontWeight = FontWeights.Bold;
         _hoverYContainer = new Border
@@ -504,7 +504,7 @@ public partial class StatsChartControl : System.Windows.Controls.UserControl
         Canvas.SetTop(_hoverYContainer, pointData.Position.Y - _hoverYContainer.DesiredSize.Height / 2);
         ChartCanvas.Children.Add(_hoverYContainer);
 
-        // 创建 X 轴标签（显示日期），带背景遮挡静态标签
+        // Build the X-axis hover label (date) with a background that covers the static label
         var xLabel = CreateLabel(pointData.DataPoint.Date.ToString("M/d"), _highlightBrush, 10);
         xLabel.FontWeight = FontWeights.Bold;
         _hoverXContainer = new Border

--- a/KeyStats.Windows/KeyStats/Views/ImportModeDialog.xaml
+++ b/KeyStats.Windows/KeyStats/Views/ImportModeDialog.xaml
@@ -1,6 +1,7 @@
 <Window x:Class="KeyStats.Views.ImportModeDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:p="clr-namespace:KeyStats.Properties"
         Title=""
         Width="420" SizeToContent="Height"
         WindowStartupLocation="CenterScreen"
@@ -38,14 +39,14 @@
                                HorizontalAlignment="Center" VerticalAlignment="Center"/>
                 </Border>
 
-                <TextBlock Text="选择导入方式"
+                <TextBlock Text="{x:Static p:Strings.ImportDialog_HeaderTitle}"
                            FontSize="18" FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimaryBrush}"/>
             </StackPanel>
 
             <!-- Description -->
             <TextBlock Grid.Row="1"
-                       Text="请选择如何处理导入的数据："
+                       Text="{x:Static p:Strings.ImportDialog_Description}"
                        FontSize="14"
                        Foreground="{DynamicResource TextSecondaryBrush}"
                        Margin="24,12,24,0"/>
@@ -87,9 +88,9 @@
                         </Style>
                     </Button.Style>
                     <StackPanel>
-                        <TextBlock Text="覆盖" FontSize="14" FontWeight="SemiBold"
+                        <TextBlock Text="{x:Static p:Strings.ImportMode_Overwrite}" FontSize="14" FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextPrimaryBrush}"/>
-                        <TextBlock Text="删除现有数据，使用导入的数据替换"
+                        <TextBlock Text="{x:Static p:Strings.ImportDialog_OverwriteDesc}"
                                    FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}"
                                    Margin="0,4,0,0"/>
                     </StackPanel>
@@ -130,9 +131,9 @@
                         </Style>
                     </Button.Style>
                     <StackPanel>
-                        <TextBlock Text="合并" FontSize="14" FontWeight="SemiBold"
+                        <TextBlock Text="{x:Static p:Strings.ImportMode_Merge}" FontSize="14" FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextPrimaryBrush}"/>
-                        <TextBlock Text="保留现有数据，将导入的数据累加合并"
+                        <TextBlock Text="{x:Static p:Strings.ImportDialog_MergeDesc}"
                                    FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}"
                                    Margin="0,4,0,0"/>
                     </StackPanel>
@@ -140,7 +141,7 @@
             </StackPanel>
 
             <!-- Cancel Button -->
-            <Button x:Name="CancelButton" Content="取消"
+            <Button x:Name="CancelButton" Content="{x:Static p:Strings.Common_Cancel}"
                     Grid.Row="3" Click="CancelButton_Click"
                     HorizontalAlignment="Right"
                     Style="{StaticResource GhostButton}"

--- a/KeyStats.Windows/KeyStats/Views/KeyHistoryWindow.xaml
+++ b/KeyStats.Windows/KeyStats/Views/KeyHistoryWindow.xaml
@@ -3,7 +3,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:KeyStats.Views.Controls"
         xmlns:viewmodels="clr-namespace:KeyStats.ViewModels"
-        Title="历史按键统计"
+        xmlns:p="clr-namespace:KeyStats.Properties"
+        Title="{x:Static p:Strings.KeyHistory_WindowTitle}"
         Width="860"
         Height="620"
         MinWidth="760"
@@ -25,11 +26,11 @@
         </Grid.RowDefinitions>
 
         <StackPanel Grid.Row="0" Margin="0,0,0,10">
-            <TextBlock Text="历史按键统计"
+            <TextBlock Text="{x:Static p:Strings.KeyHistory_HeaderTitle}"
                        FontSize="20"
                        FontWeight="SemiBold"
                        Foreground="{DynamicResource TextPrimaryBrush}"/>
-            <TextBlock Text="按键数量聚合统计，仅展示计数，不记录输入内容"
+            <TextBlock Text="{x:Static p:Strings.KeyHistory_HeaderSubtitle}"
                        Margin="0,4,0,0"
                        FontSize="12"
                        Foreground="{DynamicResource TextSecondaryBrush}"/>
@@ -37,16 +38,16 @@
 
         <Border Grid.Row="1" Background="{DynamicResource SubtleFillBrush}" CornerRadius="6" Padding="3" Margin="0,0,0,10">
             <StackPanel Orientation="Horizontal">
-                <RadioButton Content="今天" GroupName="KeyHistoryRange"
+                <RadioButton Content="{x:Static p:Strings.History_Range_Today}" GroupName="KeyHistoryRange"
                              Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="10,4"
                              IsChecked="{Binding SelectedRangeIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=0}"/>
-                <RadioButton Content="过去7天" GroupName="KeyHistoryRange"
+                <RadioButton Content="{x:Static p:Strings.History_Range_Last7Days}" GroupName="KeyHistoryRange"
                              Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="10,4"
                              IsChecked="{Binding SelectedRangeIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=1}"/>
-                <RadioButton Content="过去30天" GroupName="KeyHistoryRange"
+                <RadioButton Content="{x:Static p:Strings.History_Range_Last30Days}" GroupName="KeyHistoryRange"
                              Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="10,4"
                              IsChecked="{Binding SelectedRangeIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=2}"/>
-                <RadioButton Content="全部" GroupName="KeyHistoryRange"
+                <RadioButton Content="{x:Static p:Strings.History_Range_All}" GroupName="KeyHistoryRange"
                              Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="10,4"
                              IsChecked="{Binding SelectedRangeIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=3}"/>
             </StackPanel>
@@ -82,7 +83,7 @@
                         </Grid.RowDefinitions>
 
                         <TextBlock Grid.Row="0"
-                                   Text="按键占比（饼图）"
+                                   Text="{x:Static p:Strings.KeyHistory_PieChartTitle}"
                                    FontSize="12"
                                    FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextPrimaryBrush}"
@@ -137,7 +138,7 @@
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
                         <TextBlock Grid.Row="0"
-                                   Text="按键次数（柱状图）"
+                                   Text="{x:Static p:Strings.KeyHistory_BarChartTitle}"
                                    FontSize="12"
                                    FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextPrimaryBrush}"

--- a/KeyStats.Windows/KeyStats/Views/KeyboardHeatmapWindow.xaml
+++ b/KeyStats.Windows/KeyStats/Views/KeyboardHeatmapWindow.xaml
@@ -2,7 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:KeyStats.Views.Controls"
-        Title="键盘热力图"
+        xmlns:p="clr-namespace:KeyStats.Properties"
+        Title="{x:Static p:Strings.Heatmap_WindowTitle}"
         Width="860"
         Height="460"
         MinWidth="860"
@@ -140,12 +141,12 @@
 
         <StackPanel Grid.Row="0" Margin="0,0,0,10">
             <TextBlock x:Name="TitleText"
-                       Text="键盘热力图"
+                       Text="{x:Static p:Strings.Heatmap_HeaderTitle}"
                        FontSize="24"
                        FontWeight="Bold"
                        Foreground="{DynamicResource TextPrimaryBrush}"/>
             <TextBlock x:Name="SubtitleText"
-                       Text="按日期查看键盘热区，仅展示聚合计数，不记录输入内容"
+                       Text="{x:Static p:Strings.Heatmap_HeaderSubtitle}"
                        Margin="0,4,0,0"
                        FontSize="12"
                        Foreground="{DynamicResource TextSecondaryBrush}"/>
@@ -161,13 +162,13 @@
 
             <StackPanel Grid.Column="0" Orientation="Horizontal">
                 <Button x:Name="PrevDayButton"
-                        Content="前一天"
+                        Content="{x:Static p:Strings.Heatmap_PrevDay}"
                         Style="{DynamicResource GhostButton}"
                         Padding="12,5"
                         Margin="0,0,8,0"
                         Click="ShowPreviousDay_Click"/>
                 <Button x:Name="NextDayButton"
-                        Content="后一天"
+                        Content="{x:Static p:Strings.Heatmap_NextDay}"
                         Style="{DynamicResource GhostButton}"
                         Padding="12,5"
                         Click="ShowNextDay_Click"/>
@@ -198,7 +199,7 @@
 
             <Button x:Name="BackToTodayButton"
                     Grid.Column="2"
-                    Content="回到今天"
+                    Content="{x:Static p:Strings.Heatmap_BackToToday}"
                     Style="{DynamicResource GhostButton}"
                     Padding="12,5"
                     Click="BackToToday_Click"
@@ -309,7 +310,7 @@
                                        VerticalAlignment="Center"
                                        Foreground="{DynamicResource TextPrimaryBrush}"/>
                             <TextBlock x:Name="EmptyBadgeText"
-                                       Text="当天暂无键盘数据"
+                                       Text="{x:Static p:Strings.Heatmap_NoData}"
                                        Margin="8,0,0,0"
                                        FontSize="15"
                                        FontWeight="SemiBold"

--- a/KeyStats.Windows/KeyStats/Views/KeyboardHeatmapWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/KeyboardHeatmapWindow.xaml.cs
@@ -93,14 +93,14 @@ public partial class KeyboardHeatmapWindow : Window
 
     private void ApplyLocalizedText()
     {
-        Title = "键盘热力图";
-        TitleText.Text = "键盘热力图";
-        SubtitleText.Text = "按日期查看键盘热区，仅展示聚合计数，不记录输入内容";
-        PrevDayButton.Content = "前一天";
-        NextDayButton.Content = "后一天";
-        BackToTodayButton.Content = "回到今天";
-        EmptyBadgeText.Text = "当天暂无键盘数据";
-        DatePickerButton.ToolTip = "选择日期";
+        Title = KeyStats.Properties.Strings.Heatmap_WindowTitle;
+        TitleText.Text = KeyStats.Properties.Strings.Heatmap_HeaderTitle;
+        SubtitleText.Text = KeyStats.Properties.Strings.Heatmap_HeaderSubtitle;
+        PrevDayButton.Content = KeyStats.Properties.Strings.Heatmap_PrevDay;
+        NextDayButton.Content = KeyStats.Properties.Strings.Heatmap_NextDay;
+        BackToTodayButton.Content = KeyStats.Properties.Strings.Heatmap_BackToToday;
+        EmptyBadgeText.Text = KeyStats.Properties.Strings.Heatmap_NoData;
+        DatePickerButton.ToolTip = KeyStats.Properties.Strings.Heatmap_DatePickerTooltip;
     }
 
     private void UpdateAppearance()
@@ -137,7 +137,7 @@ public partial class KeyboardHeatmapWindow : Window
         var activeKeys = visibleCounts.Values.Count(value => value > 0);
         var totalFormatted = dayData.TotalKeyPresses.ToString("N0", CultureInfo.CurrentCulture);
         var activeFormatted = activeKeys.ToString("N0", CultureInfo.CurrentCulture);
-        SummaryText.Text = string.Format(CultureInfo.CurrentCulture, SummaryTemplate(), totalFormatted, activeFormatted);
+        SummaryText.Text = string.Format(CultureInfo.CurrentCulture, KeyStats.Properties.Strings.Heatmap_SummaryFormat, totalFormatted, activeFormatted);
         DateText.Text = DisplayDateString(_selectedDate);
 
         var hasActivity = dayData.TotalKeyPresses > 0;
@@ -148,19 +148,14 @@ public partial class KeyboardHeatmapWindow : Window
         UpdateDatePickerState();
     }
 
-    private string SummaryTemplate()
-    {
-        return "总按键: {0} · 活跃按键: {1}";
-    }
-
     private string DisplayDateString(DateTime date)
     {
         if (date.Year == DateTime.Today.Year)
         {
-            return $"{date.Month}月{date.Day}日";
+            return string.Format(CultureInfo.CurrentCulture, KeyStats.Properties.Strings.Heatmap_DateFormatShort, date.Month, date.Day);
         }
 
-        return $"{date.Year}年{date.Month}月{date.Day}日";
+        return string.Format(CultureInfo.CurrentCulture, KeyStats.Properties.Strings.Heatmap_DateFormatLong, date.Year, date.Month, date.Day);
     }
 
     private DateTime ClampDate(DateTime date)

--- a/KeyStats.Windows/KeyStats/Views/KeyboardHeatmapWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/KeyboardHeatmapWindow.xaml.cs
@@ -152,10 +152,10 @@ public partial class KeyboardHeatmapWindow : Window
     {
         if (date.Year == DateTime.Today.Year)
         {
-            return string.Format(CultureInfo.CurrentCulture, KeyStats.Properties.Strings.Heatmap_DateFormatShort, date.Month, date.Day);
+            return date.ToString("M", CultureInfo.CurrentCulture);
         }
 
-        return string.Format(CultureInfo.CurrentCulture, KeyStats.Properties.Strings.Heatmap_DateFormatLong, date.Year, date.Month, date.Day);
+        return date.ToString("d", CultureInfo.CurrentCulture);
     }
 
     private DateTime ClampDate(DateTime date)

--- a/KeyStats.Windows/KeyStats/Views/MouseCalibrationWindow.xaml
+++ b/KeyStats.Windows/KeyStats/Views/MouseCalibrationWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="KeyStats.Views.MouseCalibrationWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="距离校准 - KeyStats"
+        xmlns:p="clr-namespace:KeyStats.Properties"
+        Title="{x:Static p:Strings.Calibration_WindowTitle}"
         Width="360" SizeToContent="Height"
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize"
@@ -10,15 +11,15 @@
         PreviewKeyDown="Window_PreviewKeyDown">
 
     <StackPanel Margin="24,20">
-        <TextBlock Text="距离校准" FontSize="16" FontWeight="SemiBold"
+        <TextBlock Text="{x:Static p:Strings.Calibration_HeaderTitle}" FontSize="16" FontWeight="SemiBold"
                    Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,4"/>
-        <TextBlock Text="按回车开始记录，再按回车结束记录并计算距离系数"
+        <TextBlock Text="{x:Static p:Strings.Calibration_InstructionEnter}"
                    Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12"
                    TextWrapping="Wrap" Margin="0,0,0,16"/>
 
         <Border Style="{DynamicResource CardBorder}" Margin="0,0,0,8" Padding="14,12">
             <StackPanel>
-                <TextBlock Text="标尺长度" FontSize="13" FontWeight="SemiBold"
+                <TextBlock Text="{x:Static p:Strings.Calibration_LengthLabel}" FontSize="13" FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <TextBox x:Name="LengthTextBox" Width="80" TextAlignment="Center"
@@ -33,14 +34,14 @@
 
         <Border Style="{DynamicResource CardBorder}" Margin="0,0,0,8" Padding="14,12">
             <StackPanel>
-                <TextBlock Text="校准步骤" FontSize="13" FontWeight="SemiBold"
+                <TextBlock Text="{x:Static p:Strings.Calibration_StepsLabel}" FontSize="13" FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
-                <TextBlock x:Name="StatusText" Text="未开始，按回车开始" FontSize="12"
+                <TextBlock x:Name="StatusText" FontSize="12"
                            Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,0,0,10"/>
                 <StackPanel Orientation="Horizontal">
-                    <Button x:Name="StartButton" Content="开始" Width="70" Margin="0,0,6,0"
+                    <Button x:Name="StartButton" Content="{x:Static p:Strings.Calibration_Start}" Width="70" Margin="0,0,6,0"
                             Click="StartButton_Click"/>
-                    <Button x:Name="FinishButton" Content="完成" Width="70"
+                    <Button x:Name="FinishButton" Content="{x:Static p:Strings.Calibration_Finish}" Width="70"
                             Click="FinishButton_Click" IsEnabled="False"/>
                 </StackPanel>
             </StackPanel>
@@ -48,27 +49,27 @@
 
         <Border Style="{DynamicResource CardBorder}" Margin="0,0,0,8" Padding="14,12">
             <StackPanel>
-                <TextBlock Text="显示单位" FontSize="13" FontWeight="SemiBold"
+                <TextBlock Text="{x:Static p:Strings.Calibration_DisplayUnitLabel}" FontSize="13" FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
                 <ComboBox x:Name="UnitComboBox" Width="160" SelectionChanged="UnitComboBox_SelectionChanged">
-                    <ComboBoxItem Content="自动 (cm/m/km)" Tag="auto"/>
-                    <ComboBoxItem Content="像素 (px)" Tag="px"/>
+                    <ComboBoxItem Content="{x:Static p:Strings.Calibration_UnitAuto}" Tag="auto"/>
+                    <ComboBoxItem Content="{x:Static p:Strings.Calibration_UnitPixel}" Tag="px"/>
                 </ComboBox>
             </StackPanel>
         </Border>
 
         <Border Style="{DynamicResource CardBorder}" Margin="0,0,0,8" Padding="14,12">
             <StackPanel>
-                <TextBlock Text="当前结果" FontSize="13" FontWeight="SemiBold"
+                <TextBlock Text="{x:Static p:Strings.Calibration_CurrentResultLabel}" FontSize="13" FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
-                <TextBlock x:Name="PixelsText" Text="像素距离: --" FontSize="12"
+                <TextBlock x:Name="PixelsText" FontSize="12"
                            Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,0,0,4"/>
-                <TextBlock x:Name="ScaleText" Text="换算系数: --" FontSize="12"
+                <TextBlock x:Name="ScaleText" FontSize="12"
                            Foreground="{DynamicResource TextSecondaryBrush}"/>
             </StackPanel>
         </Border>
 
-        <TextBlock Text="提示：如需更准确，请关闭系统鼠标加速并保持匀速移动。"
+        <TextBlock Text="{x:Static p:Strings.Calibration_TipFooter}"
                    Foreground="{DynamicResource TextTertiaryBrush}" FontSize="11"
                    TextWrapping="Wrap" Margin="0,4,0,0"/>
     </StackPanel>

--- a/KeyStats.Windows/KeyStats/Views/MouseCalibrationWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/MouseCalibrationWindow.xaml.cs
@@ -23,6 +23,7 @@ public partial class MouseCalibrationWindow : Window
         InitializeComponent();
         _isInitializing = true;
         LengthTextBox.Text = "10";
+        StatusText.Text = KeyStats.Properties.Strings.Calibration_StatusIdle;
         LoadSettings();
         _isInitializing = false;
         Loaded += (_, _) => Keyboard.Focus(this);
@@ -72,7 +73,7 @@ public partial class MouseCalibrationWindow : Window
     {
         _startPoint = GetCursorPosition();
         _isMeasuring = true;
-        StatusText.Text = "已开始，移动标尺长度后按回车结束";
+        StatusText.Text = KeyStats.Properties.Strings.Calibration_StatusRecording;
         StartButton.IsEnabled = false;
         FinishButton.IsEnabled = true;
         _lastLiveDistance = 0;
@@ -84,7 +85,7 @@ public partial class MouseCalibrationWindow : Window
     {
         if (!_isMeasuring || !_startPoint.HasValue)
         {
-            StatusText.Text = "请先按回车开始";
+            StatusText.Text = KeyStats.Properties.Strings.Calibration_StatusPressEnterFirst;
             return;
         }
 
@@ -95,14 +96,14 @@ public partial class MouseCalibrationWindow : Window
 
         if (distance < 10)
         {
-            StatusText.Text = "移动距离过短，请重新校准";
+            StatusText.Text = KeyStats.Properties.Strings.Calibration_StatusMovementTooShort;
             ResetMeasureState();
             return;
         }
 
         if (!TryGetLengthCm(out var lengthCm) || lengthCm <= 0)
         {
-            StatusText.Text = "标尺长度无效";
+            StatusText.Text = KeyStats.Properties.Strings.Calibration_StatusInvalidLength;
             ResetMeasureState();
             return;
         }
@@ -113,7 +114,7 @@ public partial class MouseCalibrationWindow : Window
         UpdatePixelsText(distance);
         UpdateScaleText(metersPerPixel);
 
-        StatusText.Text = "校准完成";
+        StatusText.Text = KeyStats.Properties.Strings.Calibration_StatusComplete;
         ResetMeasureState();
     }
 
@@ -167,17 +168,19 @@ public partial class MouseCalibrationWindow : Window
 
     private void UpdatePixelsText(double? distance)
     {
-        PixelsText.Text = distance.HasValue ? $"像素距离: {distance.Value:F0} px" : "像素距离: --";
+        PixelsText.Text = distance.HasValue
+            ? string.Format(KeyStats.Properties.Strings.Calibration_PixelsLabelFormat, distance.Value)
+            : KeyStats.Properties.Strings.Calibration_PixelsLabelEmpty;
     }
 
     private void UpdateScaleText(double metersPerPixel)
     {
         if (double.IsNaN(metersPerPixel) || double.IsInfinity(metersPerPixel) || metersPerPixel <= 0)
         {
-            ScaleText.Text = "换算系数: --";
+            ScaleText.Text = KeyStats.Properties.Strings.Calibration_ScaleLabelEmpty;
             return;
         }
-        ScaleText.Text = $"换算系数: {metersPerPixel:E4} m/px";
+        ScaleText.Text = string.Format(KeyStats.Properties.Strings.Calibration_ScaleLabelFormat, metersPerPixel);
     }
 
     private void ResetMeasureState()
@@ -187,7 +190,7 @@ public partial class MouseCalibrationWindow : Window
         _startPoint = null;
         StartButton.IsEnabled = true;
         FinishButton.IsEnabled = false;
-        StatusText.Text = "未开始，按回车开始";
+        StatusText.Text = KeyStats.Properties.Strings.Calibration_StatusIdle;
     }
 
     private void StartLiveUpdate()

--- a/KeyStats.Windows/KeyStats/Views/NotificationSettingsWindow.xaml
+++ b/KeyStats.Windows/KeyStats/Views/NotificationSettingsWindow.xaml
@@ -29,14 +29,14 @@
                 <TextBlock Text="{x:Static p:Strings.NotifSettings_KeyCardTitle}" FontSize="13" FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="{x:Static p:Strings.NotifSettings_EveryPrefix}" FontSize="12"
+                    <TextBlock x:Name="KeyEveryPrefixText" FontSize="12"
                                Foreground="{DynamicResource TextSecondaryBrush}"
                                VerticalAlignment="Center"/>
                     <TextBox x:Name="KeyPressThresholdBox" Width="80" TextAlignment="Center"
                              FontSize="12" Padding="4,4" VerticalContentAlignment="Center"
                              PreviewTextInput="NumericOnly_PreviewTextInput"
                              TextChanged="OnThresholdTextChanged"/>
-                    <TextBlock Text="{x:Static p:Strings.NotifSettings_TimesSuffix}" FontSize="12"
+                    <TextBlock x:Name="KeyEverySuffixText" FontSize="12"
                                Foreground="{DynamicResource TextSecondaryBrush}"
                                VerticalAlignment="Center"/>
                 </StackPanel>
@@ -49,14 +49,14 @@
                 <TextBlock Text="{x:Static p:Strings.NotifSettings_ClickCardTitle}" FontSize="13" FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="{x:Static p:Strings.NotifSettings_EveryPrefix}" FontSize="12"
+                    <TextBlock x:Name="ClickEveryPrefixText" FontSize="12"
                                Foreground="{DynamicResource TextSecondaryBrush}"
                                VerticalAlignment="Center"/>
                     <TextBox x:Name="ClickThresholdBox" Width="80" TextAlignment="Center"
                              FontSize="12" Padding="4,4" VerticalContentAlignment="Center"
                              PreviewTextInput="NumericOnly_PreviewTextInput"
                              TextChanged="OnThresholdTextChanged"/>
-                    <TextBlock Text="{x:Static p:Strings.NotifSettings_TimesSuffix}" FontSize="12"
+                    <TextBlock x:Name="ClickEverySuffixText" FontSize="12"
                                Foreground="{DynamicResource TextSecondaryBrush}"
                                VerticalAlignment="Center"/>
                 </StackPanel>

--- a/KeyStats.Windows/KeyStats/Views/NotificationSettingsWindow.xaml
+++ b/KeyStats.Windows/KeyStats/Views/NotificationSettingsWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="KeyStats.Views.NotificationSettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="通知设置 - KeyStats"
+        xmlns:p="clr-namespace:KeyStats.Properties"
+        Title="{x:Static p:Strings.NotifSettings_WindowTitle}"
         Width="340" SizeToContent="Height"
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize"
@@ -10,14 +11,14 @@
 
     <StackPanel Margin="24,20">
         <!-- Header -->
-        <TextBlock Text="通知设置" FontSize="16" FontWeight="SemiBold"
+        <TextBlock Text="{x:Static p:Strings.NotifSettings_HeaderTitle}" FontSize="16" FontWeight="SemiBold"
                    Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,4"/>
-        <TextBlock Text="当按键或点击次数每达到设定值时发送通知"
+        <TextBlock Text="{x:Static p:Strings.NotifSettings_HeaderSubtitle}"
                    Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12"
                    TextWrapping="Wrap" Margin="0,0,0,20"/>
 
         <!-- Enable toggle -->
-        <CheckBox x:Name="EnableCheckBox" Content="启用通知"
+        <CheckBox x:Name="EnableCheckBox" Content="{x:Static p:Strings.NotifSettings_Enable}"
                   FontSize="13" Margin="0,0,0,20"
                   Foreground="{DynamicResource TextPrimaryBrush}"
                   Checked="OnSettingChanged" Unchecked="OnSettingChanged"/>
@@ -25,17 +26,17 @@
         <!-- Key press threshold -->
         <Border Style="{DynamicResource CardBorder}" Margin="0,0,0,8" Padding="14,12">
             <StackPanel>
-                <TextBlock Text="按键次数通知" FontSize="13" FontWeight="SemiBold"
+                <TextBlock Text="{x:Static p:Strings.NotifSettings_KeyCardTitle}" FontSize="13" FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="每 " FontSize="12"
+                    <TextBlock Text="{x:Static p:Strings.NotifSettings_EveryPrefix}" FontSize="12"
                                Foreground="{DynamicResource TextSecondaryBrush}"
                                VerticalAlignment="Center"/>
                     <TextBox x:Name="KeyPressThresholdBox" Width="80" TextAlignment="Center"
                              FontSize="12" Padding="4,4" VerticalContentAlignment="Center"
                              PreviewTextInput="NumericOnly_PreviewTextInput"
                              TextChanged="OnThresholdTextChanged"/>
-                    <TextBlock Text=" 次通知一次" FontSize="12"
+                    <TextBlock Text="{x:Static p:Strings.NotifSettings_TimesSuffix}" FontSize="12"
                                Foreground="{DynamicResource TextSecondaryBrush}"
                                VerticalAlignment="Center"/>
                 </StackPanel>
@@ -45,17 +46,17 @@
         <!-- Click threshold -->
         <Border Style="{DynamicResource CardBorder}" Margin="0,0,0,8" Padding="14,12">
             <StackPanel>
-                <TextBlock Text="鼠标点击通知" FontSize="13" FontWeight="SemiBold"
+                <TextBlock Text="{x:Static p:Strings.NotifSettings_ClickCardTitle}" FontSize="13" FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,0,0,8"/>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock Text="每 " FontSize="12"
+                    <TextBlock Text="{x:Static p:Strings.NotifSettings_EveryPrefix}" FontSize="12"
                                Foreground="{DynamicResource TextSecondaryBrush}"
                                VerticalAlignment="Center"/>
                     <TextBox x:Name="ClickThresholdBox" Width="80" TextAlignment="Center"
                              FontSize="12" Padding="4,4" VerticalContentAlignment="Center"
                              PreviewTextInput="NumericOnly_PreviewTextInput"
                              TextChanged="OnThresholdTextChanged"/>
-                    <TextBlock Text=" 次通知一次" FontSize="12"
+                    <TextBlock Text="{x:Static p:Strings.NotifSettings_TimesSuffix}" FontSize="12"
                                Foreground="{DynamicResource TextSecondaryBrush}"
                                VerticalAlignment="Center"/>
                 </StackPanel>
@@ -63,7 +64,7 @@
         </Border>
 
         <!-- Hint -->
-        <TextBlock Text="例如：设为 1000，则在 1000、2000、3000… 次时通知。"
+        <TextBlock Text="{x:Static p:Strings.NotifSettings_Hint}"
                    Foreground="{DynamicResource TextTertiaryBrush}" FontSize="11"
                    TextWrapping="Wrap" Margin="0,8,0,0"/>
     </StackPanel>

--- a/KeyStats.Windows/KeyStats/Views/NotificationSettingsWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/NotificationSettingsWindow.xaml.cs
@@ -13,11 +13,28 @@ public partial class NotificationSettingsWindow : Window
     public NotificationSettingsWindow()
     {
         InitializeComponent();
+        ApplyEveryFormatLabels();
         LoadSettings();
         _isLoading = false;
         Loaded += OnLoaded;
         Closed += OnClosed;
         ThemeManager.Instance.ThemeChanged += OnThemeChanged;
+    }
+
+    private void ApplyEveryFormatLabels()
+    {
+        // Split the localized "Every {0} times" sentence around {0} so the TextBox
+        // can sit between the two halves without forcing translators into a brittle
+        // prefix+suffix pair (different word orders break that pattern).
+        var format = KeyStats.Properties.Strings.NotifSettings_EveryFormat;
+        var idx = format.IndexOf("{0}", System.StringComparison.Ordinal);
+        var prefix = idx >= 0 ? format.Substring(0, idx) : format;
+        var suffix = idx >= 0 ? format.Substring(idx + 3) : string.Empty;
+
+        KeyEveryPrefixText.Text = prefix;
+        KeyEverySuffixText.Text = suffix;
+        ClickEveryPrefixText.Text = prefix;
+        ClickEverySuffixText.Text = suffix;
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)

--- a/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml
+++ b/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="KeyStats.Views.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:p="clr-namespace:KeyStats.Properties"
         Title="设置 - KeyStats"
         Width="420" SizeToContent="Height"
         WindowStartupLocation="CenterScreen"
@@ -95,6 +96,32 @@
                 </StackPanel>
                 <Button Grid.Column="1" Content="打开" Style="{DynamicResource GhostButton}"
                         MinWidth="70" Click="MouseCalibration_Click"/>
+            </Grid>
+        </Border>
+
+        <Border Style="{DynamicResource CardBorder}" Margin="0,0,0,4" Padding="14,12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="{x:Static p:Strings.Settings_Language}"
+                               FontSize="13" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextPrimaryBrush}"/>
+                    <TextBlock Text="{x:Static p:Strings.Settings_LanguageDescription}"
+                               FontSize="12"
+                               Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,4,0,0"/>
+                </StackPanel>
+                <ComboBox Grid.Column="1"
+                          x:Name="LanguageComboBox"
+                          MinWidth="140"
+                          SelectionChanged="LanguageComboBox_SelectionChanged"
+                          Loaded="LanguageComboBox_Loaded">
+                    <ComboBoxItem Content="{x:Static p:Strings.Settings_Language_System}" Tag="system"/>
+                    <ComboBoxItem Content="中文" Tag="zh-Hans"/>
+                    <ComboBoxItem Content="English" Tag="en"/>
+                </ComboBox>
             </Grid>
         </Border>
 

--- a/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml
+++ b/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:p="clr-namespace:KeyStats.Properties"
-        Title="设置 - KeyStats"
+        Title="{x:Static p:Strings.Settings_WindowTitle}"
         Width="420" SizeToContent="Height"
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize"
@@ -16,13 +16,13 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <TextBlock Text="设置" FontSize="16" FontWeight="SemiBold"
+            <TextBlock Text="{x:Static p:Strings.Settings_HeaderTitle}" FontSize="16" FontWeight="SemiBold"
                        Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center"/>
 
             <Button Grid.Column="1" Click="OpenGitHub_Click"
                     Width="28" Height="28" Padding="0" Margin="8,0,0,0"
                     Background="Transparent" BorderThickness="0" Cursor="Hand"
-                    ToolTip="打开 GitHub 仓库">
+                    ToolTip="{x:Static p:Strings.Settings_GitHubTooltip}">
                 <Button.Template>
                     <ControlTemplate TargetType="Button">
                         <Border Width="{TemplateBinding Width}"
@@ -40,7 +40,7 @@
                 </Viewbox>
             </Button>
         </Grid>
-        <TextBlock Text="在这里管理导入导出与通知设置"
+        <TextBlock Text="{x:Static p:Strings.Settings_HeaderSubtitle}"
                    Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12"
                    TextWrapping="Wrap" Margin="0,0,0,16"/>
 
@@ -51,15 +51,15 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel Grid.Column="0">
-                    <TextBlock Text="数据导入 / 导出" FontSize="13" FontWeight="SemiBold"
+                    <TextBlock Text="{x:Static p:Strings.Settings_DataImportExport}" FontSize="13" FontWeight="SemiBold"
                                Foreground="{DynamicResource TextPrimaryBrush}"/>
-                    <TextBlock Text="从 JSON 导入或导出统计数据" FontSize="12"
+                    <TextBlock Text="{x:Static p:Strings.Settings_DataImportExportDesc}" FontSize="12"
                                Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,4,0,0"/>
                 </StackPanel>
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
-                    <Button Content="导入" Style="{DynamicResource GhostButton}"
+                    <Button Content="{x:Static p:Strings.Common_Import}" Style="{DynamicResource GhostButton}"
                             MinWidth="70" Margin="0,0,6,0" Click="ImportData_Click"/>
-                    <Button Content="导出" Style="{DynamicResource GhostButton}"
+                    <Button Content="{x:Static p:Strings.Common_Export}" Style="{DynamicResource GhostButton}"
                             MinWidth="70" Click="ExportData_Click"/>
                 </StackPanel>
             </Grid>
@@ -72,12 +72,12 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel Grid.Column="0">
-                    <TextBlock Text="通知设置" FontSize="13" FontWeight="SemiBold"
+                    <TextBlock Text="{x:Static p:Strings.Settings_Notifications}" FontSize="13" FontWeight="SemiBold"
                                Foreground="{DynamicResource TextPrimaryBrush}"/>
-                    <TextBlock Text="设置按键/点击阈值通知" FontSize="12"
+                    <TextBlock Text="{x:Static p:Strings.Settings_NotificationsDesc}" FontSize="12"
                                Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,4,0,0"/>
                 </StackPanel>
-                <Button Grid.Column="1" Content="打开" Style="{DynamicResource GhostButton}"
+                <Button Grid.Column="1" Content="{x:Static p:Strings.Common_Open}" Style="{DynamicResource GhostButton}"
                         MinWidth="70" Click="NotificationSettings_Click"/>
             </Grid>
         </Border>
@@ -89,12 +89,12 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel Grid.Column="0">
-                    <TextBlock Text="距离校准" FontSize="13" FontWeight="SemiBold"
+                    <TextBlock Text="{x:Static p:Strings.Settings_DistanceCalibration}" FontSize="13" FontWeight="SemiBold"
                                Foreground="{DynamicResource TextPrimaryBrush}"/>
-                    <TextBlock Text="校准鼠标移动距离系数" FontSize="12"
+                    <TextBlock Text="{x:Static p:Strings.Settings_DistanceCalibrationDesc}" FontSize="12"
                                Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,4,0,0"/>
                 </StackPanel>
-                <Button Grid.Column="1" Content="打开" Style="{DynamicResource GhostButton}"
+                <Button Grid.Column="1" Content="{x:Static p:Strings.Common_Open}" Style="{DynamicResource GhostButton}"
                         MinWidth="70" Click="MouseCalibration_Click"/>
             </Grid>
         </Border>

--- a/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
@@ -1,7 +1,10 @@
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Windows;
+using System.Windows.Controls;
 using KeyStats.Helpers;
+using KeyStats.Services;
 
 namespace KeyStats.Views;
 
@@ -101,5 +104,67 @@ public partial class SettingsWindow : Window
         {
             MessageBox.Show(this, "无法打开 GitHub 页面。", "KeyStats", MessageBoxButton.OK, MessageBoxImage.Information);
         }
+    }
+
+    private bool _isInitializingLanguage = true;
+
+    private void LanguageComboBox_Loaded(object sender, RoutedEventArgs e)
+    {
+        var current = StatsManager.Instance.Settings.LanguagePreference ?? "system";
+        LanguageComboBox.SelectedItem = LanguageComboBox.Items
+            .Cast<ComboBoxItem>()
+            .FirstOrDefault(i => (string)i.Tag == current)
+            ?? LanguageComboBox.Items[0];
+        _isInitializingLanguage = false;
+    }
+
+    private void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isInitializingLanguage) return;
+
+        var newPref = (string?)((ComboBoxItem?)LanguageComboBox.SelectedItem)?.Tag;
+        if (string.IsNullOrEmpty(newPref)) return;
+
+        var oldPref = StatsManager.Instance.Settings.LanguagePreference ?? "system";
+        if (newPref == oldPref) return;
+
+        var result = MessageBox.Show(
+            KeyStats.Properties.Strings.Language_RestartPromptMessage,
+            KeyStats.Properties.Strings.Language_RestartPromptTitle,
+            MessageBoxButton.OKCancel,
+            MessageBoxImage.Information);
+
+        if (result == MessageBoxResult.OK)
+        {
+            StatsManager.Instance.Settings.LanguagePreference = newPref;
+            StatsManager.Instance.SaveSettings();
+            RestartApp();
+        }
+        else
+        {
+            // User cancelled — revert ComboBox to the previously persisted value.
+            _isInitializingLanguage = true;
+            LanguageComboBox.SelectedItem = LanguageComboBox.Items
+                .Cast<ComboBoxItem>()
+                .FirstOrDefault(i => (string)i.Tag == oldPref);
+            _isInitializingLanguage = false;
+        }
+    }
+
+    private static void RestartApp()
+    {
+        try
+        {
+            var exePath = Process.GetCurrentProcess().MainModule?.FileName;
+            if (!string.IsNullOrEmpty(exePath))
+            {
+                Process.Start(exePath);
+            }
+        }
+        catch
+        {
+            // If relaunch fails, the user will simply have to start the app manually.
+        }
+        Application.Current.Shutdown();
     }
 }

--- a/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
@@ -15,7 +15,7 @@ public partial class SettingsWindow : Window
     public SettingsWindow()
     {
         InitializeComponent();
-        VersionTextBlock.Text = $"\u5f53\u524d\u7248\u672c {GetDisplayVersion()}";
+        VersionTextBlock.Text = string.Format(KeyStats.Properties.Strings.Settings_VersionFormat, GetDisplayVersion());
         Loaded += OnLoaded;
         Closed += OnClosed;
         ThemeManager.Instance.ThemeChanged += OnThemeChanged;

--- a/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
@@ -102,7 +102,7 @@ public partial class SettingsWindow : Window
         }
         catch
         {
-            MessageBox.Show(this, "无法打开 GitHub 页面。", "KeyStats", MessageBoxButton.OK, MessageBoxImage.Information);
+            MessageBox.Show(this, KeyStats.Properties.Strings.Settings_OpenGitHubFailedMessage, KeyStats.Properties.Strings.App_Name, MessageBoxButton.OK, MessageBoxImage.Information);
         }
     }
 

--- a/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
@@ -136,8 +136,11 @@ public partial class SettingsWindow : Window
 
         if (result == MessageBoxResult.OK)
         {
-            StatsManager.Instance.Settings.LanguagePreference = newPref;
-            StatsManager.Instance.SaveSettings();
+            StatsManager.Instance.Settings.LanguagePreference = newPref!;
+            // SaveSettings() is debounced (2s) — RestartApp would spawn the new
+            // process before the disk write happens, so it would read the old
+            // language. FlushPendingSave forces a synchronous write.
+            StatsManager.Instance.FlushPendingSave();
             RestartApp();
         }
         else

--- a/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
@@ -136,6 +136,11 @@ public partial class SettingsWindow : Window
 
         if (result == MessageBoxResult.OK)
         {
+            App.CurrentApp?.TrackClick("settings_language_change", new System.Collections.Generic.Dictionary<string, object?>
+            {
+                ["from"] = oldPref,
+                ["to"] = newPref,
+            });
             StatsManager.Instance.Settings.LanguagePreference = newPref!;
             // SaveSettings() is debounced (2s) — RestartApp would spawn the new
             // process before the disk write happens, so it would read the old
@@ -145,6 +150,7 @@ public partial class SettingsWindow : Window
         }
         else
         {
+            App.CurrentApp?.TrackClick("settings_language_change_cancelled");
             // User cancelled — revert ComboBox to the previously persisted value.
             _isInitializingLanguage = true;
             LanguageComboBox.SelectedItem = LanguageComboBox.Items
@@ -164,9 +170,11 @@ public partial class SettingsWindow : Window
                 Process.Start(exePath);
             }
         }
-        catch
+        catch (System.Exception ex)
         {
-            // If relaunch fails, the user will simply have to start the app manually.
+            // If relaunch fails, the user will have to start the app manually.
+            // Log so the failure is recoverable from a bug report.
+            System.Console.WriteLine($"RestartApp: relaunch failed: {ex}");
         }
         Application.Current.Shutdown();
     }

--- a/KeyStats.Windows/KeyStats/Views/StatsPopupWindow.xaml
+++ b/KeyStats.Windows/KeyStats/Views/StatsPopupWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:KeyStats.Views.Controls"
         xmlns:viewmodels="clr-namespace:KeyStats.ViewModels"
+        xmlns:p="clr-namespace:KeyStats.Properties"
         Title="KeyStats"
         Width="360"
         SizeToContent="Height"
@@ -37,7 +38,7 @@
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" Text="今日统计" FontSize="14" FontWeight="SemiBold"
+                <TextBlock Grid.Column="0" Text="{x:Static p:Strings.Stats_TodayHeader}" FontSize="14" FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimaryBrush}"/>
                 <ToggleButton x:Name="PeakToggle" Grid.Column="2"
                               IsChecked="{Binding IsPeakPopupOpen, Mode=TwoWay}"
@@ -94,7 +95,7 @@
                                     <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
                                         <TextBlock Text="&#xE945;" FontFamily="Segoe MDL2 Assets" FontSize="10"
                                                    Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                                        <TextBlock Text="峰值按键速度(KPS)" FontSize="10"
+                                        <TextBlock Text="{x:Static p:Strings.Stats_PeakKpsTooltipLabel}" FontSize="10"
                                                    Foreground="{DynamicResource TextSecondaryBrush}"/>
                                     </StackPanel>
                                     <TextBlock Text="{Binding PeakKPS}" FontSize="20" FontWeight="SemiBold"
@@ -104,7 +105,7 @@
                                     <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
                                         <TextBlock Text="&#xE945;" FontFamily="Segoe MDL2 Assets" FontSize="10"
                                                    Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" Margin="0,0,4,0"/>
-                                        <TextBlock Text="峰值点击速度(CPS)" FontSize="10"
+                                        <TextBlock Text="{x:Static p:Strings.Stats_PeakCpsTooltipLabel}" FontSize="10"
                                                    Foreground="{DynamicResource TextSecondaryBrush}"/>
                                     </StackPanel>
                                     <TextBlock Text="{Binding PeakCPS}" FontSize="20" FontWeight="SemiBold"
@@ -124,10 +125,10 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <Border Grid.Column="0" Style="{DynamicResource CardBorder}" Padding="9,8">
-                    <controls:StatItemControl Icon="&#xE765;" Title="按键次数" Value="{Binding KeyPresses}"/>
+                    <controls:StatItemControl Icon="&#xE765;" Title="{x:Static p:Strings.Stats_KeyPresses}" Value="{Binding KeyPresses}"/>
                 </Border>
                 <Border Grid.Column="2" Style="{DynamicResource CardBorder}" Padding="9,8">
-                    <controls:StatItemControl Icon="&#xE8B0;" Title="鼠标点击" Value="{Binding TotalClicks}"/>
+                    <controls:StatItemControl Icon="&#xE8B0;" Title="{x:Static p:Strings.Stats_MouseClicks}" Value="{Binding TotalClicks}"/>
                 </Border>
             </Grid>
 
@@ -153,7 +154,7 @@
                                        VerticalAlignment="Center"/>
                         </Border>
                         <TextBlock Grid.Column="1"
-                                   Text="鼠标点击明细"
+                                   Text="{x:Static p:Strings.Stats_MouseClickDetail}"
                                    FontSize="10"
                                    Foreground="{DynamicResource TextSecondaryBrush}"
                                    VerticalAlignment="Center"/>
@@ -170,19 +171,19 @@
 
                         <Border Grid.Column="0" Background="{DynamicResource SubtleFillBrush}" CornerRadius="7" Padding="10,8">
                             <StackPanel>
-                                <TextBlock Text="左键" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}"/>
+                                <TextBlock Text="{x:Static p:Strings.Click_Left}" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}"/>
                                 <TextBlock Text="{Binding LeftClicks}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,2,0,0"/>
                             </StackPanel>
                         </Border>
                         <Border Grid.Column="2" Background="{DynamicResource SubtleFillBrush}" CornerRadius="7" Padding="10,8">
                             <StackPanel>
-                                <TextBlock Text="中键" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}"/>
+                                <TextBlock Text="{x:Static p:Strings.Click_Middle}" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}"/>
                                 <TextBlock Text="{Binding MiddleClicks}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,2,0,0"/>
                             </StackPanel>
                         </Border>
                         <Border Grid.Column="4" Background="{DynamicResource SubtleFillBrush}" CornerRadius="7" Padding="10,8">
                             <StackPanel>
-                                <TextBlock Text="右键" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}"/>
+                                <TextBlock Text="{x:Static p:Strings.Click_Right}" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}"/>
                                 <TextBlock Text="{Binding RightClicks}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,2,0,0"/>
                             </StackPanel>
                         </Border>
@@ -207,13 +208,13 @@
 
                         <Border Grid.Column="0" Background="{DynamicResource SubtleFillBrush}" CornerRadius="7" Padding="10,8" Opacity="0.9">
                             <StackPanel>
-                                <TextBlock Text="后退" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}"/>
+                                <TextBlock Text="{x:Static p:Strings.Click_Back}" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}"/>
                                 <TextBlock Text="{Binding SideBackClicks}" FontSize="16" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,2,0,0"/>
                             </StackPanel>
                         </Border>
                         <Border Grid.Column="2" Background="{DynamicResource SubtleFillBrush}" CornerRadius="7" Padding="10,8" Opacity="0.9">
                             <StackPanel>
-                                <TextBlock Text="前进" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}"/>
+                                <TextBlock Text="{x:Static p:Strings.Click_Forward}" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}"/>
                                 <TextBlock Text="{Binding SideForwardClicks}" FontSize="16" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,2,0,0"/>
                             </StackPanel>
                         </Border>
@@ -228,10 +229,10 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <Border Grid.Column="0" Style="{DynamicResource CardBorder}" Padding="8,7">
-                    <controls:StatItemControl Icon="&#xE8AB;" Title="鼠标移动" Value="{Binding MouseDistance}"/>
+                    <controls:StatItemControl Icon="&#xE8AB;" Title="{x:Static p:Strings.Stats_MouseDistance}" Value="{Binding MouseDistance}"/>
                 </Border>
                 <Border Grid.Column="2" Style="{DynamicResource CardBorder}" Padding="8,7">
-                    <controls:StatItemControl Icon="&#xE74A;" Title="滚轮滚动" Value="{Binding ScrollDistance}"/>
+                    <controls:StatItemControl Icon="&#xE74A;" Title="{x:Static p:Strings.Stats_ScrollDistance}" Value="{Binding ScrollDistance}"/>
                 </Border>
             </Grid>
 
@@ -243,10 +244,10 @@
                     <ColumnDefinition Width="6"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" Text="按键分布" Style="{DynamicResource SectionTitle}" Margin="0" VerticalAlignment="Center"/>
-                <Button Grid.Column="1" Content="键盘热力图" Style="{DynamicResource GhostButton}"
+                <TextBlock Grid.Column="0" Text="{x:Static p:Strings.Stats_KeyBreakdown}" Style="{DynamicResource SectionTitle}" Margin="0" VerticalAlignment="Center"/>
+                <Button Grid.Column="1" Content="{x:Static p:Strings.Stats_KeyboardHeatmap}" Style="{DynamicResource GhostButton}"
                         Click="OpenKeyboardHeatmap_Click" Padding="12,5"/>
-                <Button Grid.Column="3" Content="历史按键统计" Style="{DynamicResource GhostButton}"
+                <Button Grid.Column="3" Content="{x:Static p:Strings.Stats_KeyHistory}" Style="{DynamicResource GhostButton}"
                         Click="OpenKeyHistory_Click" Padding="12,5"/>
             </Grid>
             <Border Style="{DynamicResource CardBorder}" Padding="8,6" Margin="0,0,0,6">
@@ -262,8 +263,8 @@
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" Text="活跃应用" Style="{DynamicResource SectionTitle}" Margin="0" VerticalAlignment="Center"/>
-                <Button Grid.Column="1" Content="应用统计详情" Style="{DynamicResource GhostButton}"
+                <TextBlock Grid.Column="0" Text="{x:Static p:Strings.Stats_ActiveApps}" Style="{DynamicResource SectionTitle}" Margin="0" VerticalAlignment="Center"/>
+                <Button Grid.Column="1" Content="{x:Static p:Strings.Stats_AppStatsDetail}" Style="{DynamicResource GhostButton}"
                         Click="OpenAppStats_Click" Padding="12,5"/>
             </Grid>
             <Border Style="{DynamicResource CardBorder}" Padding="8,6" Margin="0,0,0,6">
@@ -367,7 +368,7 @@
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" Text="历史记录" Style="{DynamicResource SectionTitle}" Margin="0" VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="0" Text="{x:Static p:Strings.Stats_HistoryHeader}" Style="{DynamicResource SectionTitle}" Margin="0" VerticalAlignment="Center"/>
                 <Border Grid.Column="2" Background="{DynamicResource SubtleFillBrush}" CornerRadius="4" Padding="2">
                     <StackPanel Orientation="Horizontal">
                         <RadioButton GroupName="ChartStyle"
@@ -375,7 +376,7 @@
                                      IsChecked="{Binding SelectedChartStyleIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=0}">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#xE9D9;" FontFamily="Segoe MDL2 Assets" FontSize="9" VerticalAlignment="Center"/>
-                                <TextBlock Text=" 折线" FontSize="10" VerticalAlignment="Center"/>
+                                <TextBlock Text="{x:Static p:Strings.Chart_Line}" FontSize="10" VerticalAlignment="Center" Margin="2,0,0,0"/>
                             </StackPanel>
                         </RadioButton>
                         <RadioButton GroupName="ChartStyle"
@@ -383,7 +384,7 @@
                                      IsChecked="{Binding SelectedChartStyleIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=1}">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#xE9D2;" FontFamily="Segoe MDL2 Assets" FontSize="9" VerticalAlignment="Center"/>
-                                <TextBlock Text=" 柱状" FontSize="10" VerticalAlignment="Center"/>
+                                <TextBlock Text="{x:Static p:Strings.Chart_Bar}" FontSize="10" VerticalAlignment="Center" Margin="2,0,0,0"/>
                             </StackPanel>
                         </RadioButton>
                     </StackPanel>
@@ -401,10 +402,10 @@
                 <!-- Range -->
                 <Border Grid.Column="0" Background="{DynamicResource SubtleFillBrush}" CornerRadius="5" Padding="3">
                     <StackPanel Orientation="Horizontal">
-                        <RadioButton Content="7天" GroupName="Range"
+                        <RadioButton Content="{x:Static p:Strings.Range_7Days}" GroupName="Range"
                                      Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="8,4"
                                      IsChecked="{Binding SelectedRangeIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=0}"/>
-                        <RadioButton Content="30天" GroupName="Range"
+                        <RadioButton Content="{x:Static p:Strings.Range_30Days}" GroupName="Range"
                                      Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="8,4"
                                      IsChecked="{Binding SelectedRangeIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=1}"/>
                     </StackPanel>
@@ -419,16 +420,16 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
-                        <RadioButton Grid.Column="0" Content="点击" GroupName="Metric"
+                        <RadioButton Grid.Column="0" Content="{x:Static p:Strings.Metric_Clicks}" GroupName="Metric"
                                      Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="6,4"
                                      IsChecked="{Binding SelectedMetricIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=0}"/>
-                        <RadioButton Grid.Column="1" Content="按键" GroupName="Metric"
+                        <RadioButton Grid.Column="1" Content="{x:Static p:Strings.Metric_Keys}" GroupName="Metric"
                                      Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="6,4"
                                      IsChecked="{Binding SelectedMetricIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=1}"/>
-                        <RadioButton Grid.Column="2" Content="移动" GroupName="Metric"
+                        <RadioButton Grid.Column="2" Content="{x:Static p:Strings.Metric_Move}" GroupName="Metric"
                                      Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="6,4"
                                      IsChecked="{Binding SelectedMetricIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=2}"/>
-                        <RadioButton Grid.Column="3" Content="滚动" GroupName="Metric"
+                        <RadioButton Grid.Column="3" Content="{x:Static p:Strings.Metric_Scroll}" GroupName="Metric"
                                      Style="{DynamicResource SegmentedButton}" FontSize="11" Padding="6,4"
                                      IsChecked="{Binding SelectedMetricIndex, Converter={StaticResource IntToBoolConverter}, ConverterParameter=3}"/>
                     </Grid>

--- a/KeyStats.Windows/KeyStats/Views/StatsPopupWindow.xaml.cs
+++ b/KeyStats.Windows/KeyStats/Views/StatsPopupWindow.xaml.cs
@@ -82,12 +82,12 @@ public partial class StatsPopupWindow : Window
             PositionNearTray();
         }
         
-        // 追踪页面浏览
+        // Track page view
         App.CurrentApp?.TrackPageView("stats_popup");
-        
+
         if (!_isWindowMode)
         {
-            // 确定动画方向（从任务栏方向滑入）
+            // Determine animation direction (slide in from taskbar side)
             var mousePos = System.Windows.Forms.Control.MousePosition;
             var screen = Screen.FromPoint(new System.Drawing.Point(mousePos.X, mousePos.Y)) ?? Screen.PrimaryScreen;
             if (screen != null)
@@ -145,7 +145,7 @@ public partial class StatsPopupWindow : Window
         var transform = (System.Windows.Media.TranslateTransform)FindName("WindowTransform");
         if (transform == null) return;
         
-        // 淡入动画
+        // Fade-in animation
         var opacityAnimation = new DoubleAnimation
         {
             From = 0,
@@ -153,8 +153,8 @@ public partial class StatsPopupWindow : Window
             Duration = TimeSpan.FromMilliseconds(200),
             EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
         };
-        
-        // 滑入动画
+
+        // Slide-in animation
         var translateXAnimation = new DoubleAnimation
         {
             From = startX,
@@ -282,7 +282,7 @@ public partial class StatsPopupWindow : Window
             return;
         }
         
-        // 确定滑出方向（向任务栏方向滑出）
+        // Determine slide-out direction (toward taskbar side)
         var mousePos = System.Windows.Forms.Control.MousePosition;
         var screen = Screen.FromPoint(new System.Drawing.Point(mousePos.X, mousePos.Y)) ?? Screen.PrimaryScreen;
         if (screen == null)
@@ -304,26 +304,26 @@ public partial class StatsPopupWindow : Window
         
         if (taskbarAtBottom)
         {
-            endY = slideDistance; // 向下滑出
+            endY = slideDistance; // slide down
         }
         else if (taskbarAtTop)
         {
-            endY = -slideDistance; // 向上滑出
+            endY = -slideDistance; // slide up
         }
         else if (taskbarAtRight)
         {
-            endX = slideDistance; // 向右滑出
+            endX = slideDistance; // slide right
         }
         else if (taskbarAtLeft)
         {
-            endX = -slideDistance; // 向左滑出
+            endX = -slideDistance; // slide left
         }
         else
         {
-            endY = slideDistance; // 默认向下滑出
+            endY = slideDistance; // default: slide down
         }
-        
-        // 淡出动画
+
+        // Fade-out animation
         var opacityAnimation = new DoubleAnimation
         {
             From = Opacity,
@@ -332,7 +332,7 @@ public partial class StatsPopupWindow : Window
             EasingFunction = new CubicEase { EasingMode = EasingMode.EaseIn }
         };
         
-        // 滑出动画
+        // Slide-out animation
         var translateXAnimation = new DoubleAnimation
         {
             From = transform.X,
@@ -349,7 +349,7 @@ public partial class StatsPopupWindow : Window
             EasingFunction = new CubicEase { EasingMode = EasingMode.EaseIn }
         };
         
-        // 动画完成后关闭窗口
+        // Close the window after the animation completes
         opacityAnimation.Completed += (s, e) => Close();
         
         BeginAnimation(UIElement.OpacityProperty, opacityAnimation);
@@ -359,35 +359,35 @@ public partial class StatsPopupWindow : Window
 
     private void PositionNearTray()
     {
-        // 获取鼠标当前位置（优先使用点击时的锚点，避免异步延迟导致位置偏移）
+        // Get current mouse position (prefer the click-time anchor to avoid async delay drift)
         var mousePos = _anchorPoint ?? System.Windows.Forms.Control.MousePosition;
         var mouseX = mousePos.X;
         var mouseY = mousePos.Y;
 
-        // 获取主屏幕信息
+        // Get the primary screen info
         var screen = Screen.FromPoint(new System.Drawing.Point(mouseX, mouseY));
         if (screen == null) screen = Screen.PrimaryScreen;
         if (screen == null) return;
 
         var workingArea = screen.WorkingArea;
         var screenBounds = screen.Bounds;
-        
-        // DPI 缩放因子（独立处理 X/Y，兼容非等比 DPI）
+
+        // DPI scale factors (handle X/Y independently for non-uniform DPI)
         var transformToDevice = PresentationSource.FromVisual(this)?.CompositionTarget?.TransformToDevice;
         var dpiScaleX = transformToDevice?.M11 ?? 1.0;
         var dpiScaleY = transformToDevice?.M22 ?? dpiScaleX;
 
-        // 确定任务栏位置
+        // Determine taskbar position
         bool taskbarAtBottom = workingArea.Bottom < screenBounds.Bottom;
         bool taskbarAtTop = workingArea.Top > screenBounds.Top;
         bool taskbarAtRight = workingArea.Right < screenBounds.Right;
         bool taskbarAtLeft = workingArea.Left > screenBounds.Left;
 
-        // 系统托盘区域预留空间（避免遮挡图标）
-        const int trayAreaWidth = 250; // 系统托盘区域宽度（右侧）
-        const int spacing = 10; // 窗口与鼠标/任务栏的最小间距
+        // Reserve space for the system tray area (avoid covering icons)
+        const int trayAreaWidth = 250; // System tray area width (right side)
+        const int spacing = 10; // Minimum gap between window and mouse/taskbar
 
-        // 避免高缩放下窗口超出工作区：先按当前屏幕可用高度约束窗口，再读取实际尺寸参与定位
+        // Prevent window from exceeding working area at high DPI: clamp window by current screen's available height first, then read actual size for positioning
         var maxHeightDip = Math.Max(200, (workingArea.Height - spacing * 2) / dpiScaleY);
         if (Math.Abs(MaxHeight - maxHeightDip) > 0.5)
         {
@@ -407,20 +407,20 @@ public partial class StatsPopupWindow : Window
 
         if (taskbarAtBottom)
         {
-            // 任务栏在底部：窗口显示在鼠标上方
+            // Taskbar at bottom: show window above the mouse
             left = mouseX - windowWidth / 2;
-            
-            // 如果鼠标在屏幕右侧（系统托盘区域），窗口定位到左侧，避免遮挡图标
+
+            // If the mouse is on the right side of the screen (system tray area), position the window to the left to avoid covering icons
             if (mouseX > screenBounds.Right - trayAreaWidth)
             {
-                // 窗口定位到屏幕右侧，但留出系统托盘区域
+                // Position the window to the right side of the screen, but leave space for the system tray area
                 left = screenBounds.Right - windowWidth - trayAreaWidth - spacing;
             }
-            
-            // 窗口紧贴鼠标上方显示，只保留很小的间距
+
+            // Display the window just above the mouse with a tiny gap
             top = mouseY - windowHeight - spacing;
-            
-            // 确保窗口完全在工作区域内
+
+            // Ensure the window stays fully within the working area
             if (top + windowHeight > workingArea.Bottom - spacing)
             {
                 top = workingArea.Bottom - windowHeight - spacing;
@@ -428,31 +428,31 @@ public partial class StatsPopupWindow : Window
         }
         else if (taskbarAtTop)
         {
-            // 任务栏在顶部：窗口显示在鼠标下方
+            // Taskbar at top: show window below the mouse
             left = mouseX - windowWidth / 2;
             top = workingArea.Top + 10;
         }
         else if (taskbarAtRight)
         {
-            // 任务栏在右侧：窗口显示在鼠标左侧
-            // 如果鼠标在任务栏右侧区域（可能有点击托盘图标），窗口定位到更左侧
+            // Taskbar on the right: show window to the left of the mouse
+            // If the mouse is in the right-side taskbar region (likely a tray-icon click), position the window further left
             left = workingArea.Right - windowWidth - trayAreaWidth - 10;
             top = mouseY - windowHeight / 2;
         }
         else if (taskbarAtLeft)
         {
-            // 任务栏在左侧：窗口显示在鼠标右侧
+            // Taskbar on the left: show window to the right of the mouse
             left = workingArea.Left + 10;
             top = mouseY - windowHeight / 2;
         }
         else
         {
-            // 默认：窗口显示在鼠标附近
+            // Default: show window near the mouse
             left = mouseX - windowWidth / 2;
             top = mouseY - windowHeight / 2;
         }
 
-        // 确保窗口完全在屏幕可见区域内
+        // Ensure the window is fully within the visible screen area
         if (left < workingArea.Left)
             left = workingArea.Left + 10;
         if (left + windowWidth > workingArea.Right)
@@ -460,11 +460,11 @@ public partial class StatsPopupWindow : Window
         if (top < workingArea.Top)
             top = workingArea.Top + 10;
 
-        // 确保窗口底部不会延伸到任务栏区域，保持小间距
+        // Ensure the window bottom does not extend into the taskbar area, leaving a small gap
         if (top + windowHeight > workingArea.Bottom - spacing)
             top = workingArea.Bottom - windowHeight - spacing;
 
-        // 转换为 WPF 坐标（考虑 DPI）
+        // Convert to WPF coordinates (factoring in DPI)
         Left = left / dpiScaleX;
         Top = top / dpiScaleY;
     }

--- a/docs/superpowers/plans/2026-04-29-windows-i18n.md
+++ b/docs/superpowers/plans/2026-04-29-windows-i18n.md
@@ -1,0 +1,2195 @@
+# Windows i18n Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bilingual (zh-Hans / English) support to KeyStats Windows. App auto-detects system language at startup (strict simplified Chinese → 中文; everything else → English) with manual override in Settings (restart to apply).
+
+**Architecture:** `.resx` resource files + a hand-written strongly-typed `Strings` accessor class (no Visual Studio Designer dependency). `LocalizationManager` sets `Thread.CurrentUICulture` once at startup based on `AppSettings.LanguagePreference`. XAML uses `{x:Static p:Strings.Foo}`; C# uses `Strings.Foo`. Switch language in Settings → restart prompt → relaunch app.
+
+**Tech Stack:** WPF + .NET Framework 4.8, C# 10, XAML, `System.Resources.ResourceManager`. SDK-style `.csproj`. No automated tests in this project — verification is `dotnet build` (compile-time key checks) plus manual smoke testing per window.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-windows-i18n-design.md`
+
+**Working directory for all `dotnet` commands:** `KeyStats.Windows/`
+
+**Verification gates per task:**
+- **Build gate:** `dotnet build KeyStats/KeyStats.csproj -c Debug` from `KeyStats.Windows/` must succeed (catches missing `Strings.*` keys at compile time).
+- **Smoke gate:** Launch the app on Windows, open the affected window in both Chinese and English (via Settings dropdown), visually confirm strings render correctly. The macOS-based engineer should clearly note "smoke gate deferred to Windows reviewer" if running on macOS — DO NOT mark a task complete without this signal in the commit message.
+
+---
+
+## File Structure
+
+### New files
+
+| Path | Responsibility |
+|---|---|
+| `KeyStats.Windows/KeyStats/Properties/Strings.resx` | English / neutral resource file (also fallback). XML, ~200 keys. |
+| `KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx` | Simplified Chinese resource file. XML, mirrors `Strings.resx`. |
+| `KeyStats.Windows/KeyStats/Properties/Strings.cs` | Hand-written strongly-typed accessor class. One static property per key, returns `ResourceManager.GetString("Foo") ?? "Foo"`. Grows incrementally with each task. |
+| `KeyStats.Windows/KeyStats/Helpers/LocalizationManager.cs` | Static helper. `ApplyAtStartup(string preference)` sets `Thread.CurrentUICulture` and `CultureInfo.DefaultThreadCurrentUICulture`. `DetectFromSystem()` picks zh-Hans for `zh-CN`/`zh-Hans*`/`zh`, otherwise `en`. |
+
+### Modified files (25 source files; ~358 hardcoded Chinese occurrences)
+
+| File | Approx hits | Modification |
+|---|---|---|
+| `KeyStats/KeyStats.csproj` | — | Confirm SDK auto-handles `.resx`; add `<EmbeddedResource>` only if needed. |
+| `KeyStats/Models/AppSettings.cs` | 0 | Add `LanguagePreference` string field, default `"system"`. |
+| `KeyStats/App.xaml.cs` | 39 | Wire `LocalizationManager.ApplyAtStartup`; mutex retry; tray menu; toast text; mutex-failure fallback (English). |
+| `KeyStats/Views/SettingsWindow.xaml` + `.cs` | 14 + 1 | Existing strings + new Language card + restart flow. |
+| `KeyStats/Views/StatsPopupWindow.xaml` + `.cs` | 27 + 34 | Largest file — main popup. |
+| `KeyStats/Views/AppStatsWindow.xaml` | 8 | App-by-app stats. |
+| `KeyStats/Views/KeyboardHeatmapWindow.xaml` + `.cs` | 7 + 11 | Heatmap window. |
+| `KeyStats/Views/KeyHistoryWindow.xaml` | 9 | History timeline. |
+| `KeyStats/Views/MouseCalibrationWindow.xaml` + `.cs` | 15 + 9 | Calibration wizard. |
+| `KeyStats/Views/NotificationSettingsWindow.xaml` | 11 | Notification thresholds. |
+| `KeyStats/Views/ImportModeDialog.xaml` | 7 | Merge / overwrite chooser. |
+| `KeyStats/Views/ConfirmDialog.xaml` + `.cs` | 4 + 3 | Generic confirm. |
+| `KeyStats/Views/Controls/KeyBreakdownControl.xaml` | 1 | Empty state. |
+| `KeyStats/Views/Controls/StatsChartControl.xaml.cs` | 15 | Chart legend / tooltip. |
+| `KeyStats/Views/Controls/KeyDistributionPieChartControl.xaml.cs` | 4 | Pie chart legend. |
+| `KeyStats/ViewModels/StatsPopupViewModel.cs` | 2 | Format strings. |
+| `KeyStats/ViewModels/AppStatsViewModel.cs` | 11 | Column headers, summary. |
+| `KeyStats/ViewModels/KeyHistoryViewModel.cs` | 2 | Range labels. |
+| `KeyStats/Services/StatsManager.cs` | 11 | Exception messages translated; Console logs converted to English (not localized). |
+| `KeyStats/Services/NotificationService.cs` | 3 | Toast templates. |
+| `KeyStats/Services/InputMonitorService.cs` | 6 | Console logs converted to English. |
+
+---
+
+## Naming conventions (used throughout this plan)
+
+- **Key style:** `Category_Detail` (PascalCase, underscore separator). Examples: `Settings_Title`, `Tray_OpenMainWindow`, `Notification_KeyThresholdReachedFormat`.
+- **Format strings:** suffix `Format`, use `{0}`/`{1}` placeholders (C# `string.Format`).
+- **Key categories:** `App_*`, `Common_*`, `Tray_*`, `Settings_*`, `Stats_*`, `Mouse_*`, `Click_*`, `KeyHistory_*`, `Heatmap_*`, `AppStats_*`, `Notif_*`, `NotifSettings_*`, `Calibration_*`, `Import_*`, `Toast_*`, `Error_*`, `Confirm_*`, `Language_*`, `Chart_*`, `KeyBreakdown_*`.
+- **Translation reuse:** when the same concept exists in `KeyStats/zh-Hans.lproj/Localizable.strings` (macOS), reuse the Chinese exactly. Each task lists which macOS keys are reused.
+
+---
+
+## Task 1: Bootstrap resource files and Strings accessor
+
+Create the three resource files and a minimal `Strings.cs` with foundational keys. Get to a build-passing baseline before touching any UI code.
+
+**Files:**
+- Create: `KeyStats.Windows/KeyStats/Properties/Strings.resx`
+- Create: `KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx`
+- Create: `KeyStats.Windows/KeyStats/Properties/Strings.cs`
+
+- [ ] **Step 1: Create `Strings.resx` (English / neutral)**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+
+  <data name="App_Name" xml:space="preserve"><value>KeyStats</value></data>
+  <data name="Common_Ok" xml:space="preserve"><value>OK</value></data>
+  <data name="Common_Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Common_Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Common_Retry" xml:space="preserve"><value>Retry</value></data>
+  <data name="Common_Open" xml:space="preserve"><value>Open</value></data>
+  <data name="Common_Import" xml:space="preserve"><value>Import</value></data>
+  <data name="Common_Export" xml:space="preserve"><value>Export</value></data>
+  <data name="Error_AppAlreadyRunning" xml:space="preserve"><value>KeyStats is already running.</value></data>
+  <data name="Error_StartupFailedFormat" xml:space="preserve"><value>Startup error: {0}</value></data>
+  <data name="Error_AppErrorTitle" xml:space="preserve"><value>KeyStats Error</value></data>
+</root>
+```
+
+- [ ] **Step 2: Create `Strings.zh-Hans.resx` (Simplified Chinese)**
+
+Identical XML structure as Step 1, but with Chinese values. Only the `<data>` elements differ:
+
+```xml
+  <data name="App_Name" xml:space="preserve"><value>按键统计</value></data>
+  <data name="Common_Ok" xml:space="preserve"><value>确定</value></data>
+  <data name="Common_Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="Common_Close" xml:space="preserve"><value>关闭</value></data>
+  <data name="Common_Retry" xml:space="preserve"><value>重试</value></data>
+  <data name="Common_Open" xml:space="preserve"><value>打开</value></data>
+  <data name="Common_Import" xml:space="preserve"><value>导入</value></data>
+  <data name="Common_Export" xml:space="preserve"><value>导出</value></data>
+  <data name="Error_AppAlreadyRunning" xml:space="preserve"><value>按键统计已在运行中。</value></data>
+  <data name="Error_StartupFailedFormat" xml:space="preserve"><value>启动错误：{0}</value></data>
+  <data name="Error_AppErrorTitle" xml:space="preserve"><value>按键统计错误</value></data>
+```
+
+> The full XSD schema and `<resheader>` block must be present (copy from Step 1's resx). Only the `<data>` values change between the two files.
+
+- [ ] **Step 3: Create `Strings.cs` (hand-written strongly-typed accessor)**
+
+```csharp
+using System.Resources;
+
+namespace KeyStats.Properties;
+
+// Hand-written accessor class. Each migration task adds new properties here.
+// Returns the key name as fallback if a translation is missing — surfaces gaps loudly.
+public static class Strings
+{
+    private static readonly ResourceManager Rm =
+        new ResourceManager("KeyStats.Properties.Strings", typeof(Strings).Assembly);
+
+    private static string Get(string key) => Rm.GetString(key) ?? key;
+
+    public static string App_Name => Get(nameof(App_Name));
+    public static string Common_Ok => Get(nameof(Common_Ok));
+    public static string Common_Cancel => Get(nameof(Common_Cancel));
+    public static string Common_Close => Get(nameof(Common_Close));
+    public static string Common_Retry => Get(nameof(Common_Retry));
+    public static string Common_Open => Get(nameof(Common_Open));
+    public static string Common_Import => Get(nameof(Common_Import));
+    public static string Common_Export => Get(nameof(Common_Export));
+    public static string Error_AppAlreadyRunning => Get(nameof(Error_AppAlreadyRunning));
+    public static string Error_StartupFailedFormat => Get(nameof(Error_StartupFailedFormat));
+    public static string Error_AppErrorTitle => Get(nameof(Error_AppErrorTitle));
+}
+```
+
+- [ ] **Step 4: Verify SDK-style auto-include works**
+
+The SDK targets auto-include `.resx` files under the project as `<EmbeddedResource>`. Confirm by inspecting `KeyStats.csproj` — no manual `<EmbeddedResource Include="Properties\Strings.resx"/>` element is needed. If the build fails at Step 5 with "resource not found", add this `<ItemGroup>` to `KeyStats.csproj`:
+
+```xml
+<ItemGroup>
+  <EmbeddedResource Update="Properties\Strings.resx">
+    <ManifestResourceName>KeyStats.Properties.Strings</ManifestResourceName>
+  </EmbeddedResource>
+  <EmbeddedResource Update="Properties\Strings.zh-Hans.resx">
+    <ManifestResourceName>KeyStats.Properties.Strings.zh-Hans</ManifestResourceName>
+  </EmbeddedResource>
+</ItemGroup>
+```
+
+- [ ] **Step 5: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+Expected: build succeeds. Inspect `KeyStats/bin/Debug/net48/`:
+- Main DLL `KeyStats.exe` should embed `KeyStats.Properties.Strings.resources`
+- Subfolder `zh-Hans/KeyStats.resources.dll` (satellite assembly) should exist
+
+If the satellite folder is missing, the `.zh-Hans.resx` infix isn't being picked up — add the `<ItemGroup>` from Step 4.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/KeyStats.csproj
+git commit -m "feat(i18n): bootstrap Strings.resx + .zh-Hans.resx + accessor"
+```
+
+---
+
+## Task 2: Create LocalizationManager
+
+**Files:**
+- Create: `KeyStats.Windows/KeyStats/Helpers/LocalizationManager.cs`
+
+- [ ] **Step 1: Write `LocalizationManager.cs`**
+
+```csharp
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace KeyStats.Helpers;
+
+public static class LocalizationManager
+{
+    // Must be called before any UI loads (typically at the top of App.OnStartup,
+    // after settings are loaded but before any window is constructed).
+    public static void ApplyAtStartup(string? languagePreference)
+    {
+        var culture = Resolve(languagePreference);
+        Thread.CurrentThread.CurrentUICulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        // CurrentCulture (number/date formats) is intentionally left as system default.
+    }
+
+    public static CultureInfo Resolve(string? preference)
+    {
+        return preference switch
+        {
+            "zh-Hans" => new CultureInfo("zh-Hans"),
+            "en"      => new CultureInfo("en"),
+            _         => DetectFromSystem(),  // "system", null, or any unknown value
+        };
+    }
+
+    private static CultureInfo DetectFromSystem()
+    {
+        var sys = CultureInfo.CurrentUICulture;
+        // Strict simplified Chinese only:
+        //   zh-CN, zh-Hans, zh-Hans-CN, zh → 中文
+        //   zh-TW, zh-HK, zh-Hant*, en-*, ja-*, etc. → English
+        if (sys.Name.StartsWith("zh-Hans", StringComparison.OrdinalIgnoreCase) ||
+            sys.Name.Equals("zh-CN", StringComparison.OrdinalIgnoreCase) ||
+            sys.Name.Equals("zh", StringComparison.OrdinalIgnoreCase))
+        {
+            return new CultureInfo("zh-Hans");
+        }
+        return new CultureInfo("en");
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Helpers/LocalizationManager.cs
+git commit -m "feat(i18n): add LocalizationManager for culture detection"
+```
+
+---
+
+## Task 3: Add LanguagePreference to AppSettings
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/Models/AppSettings.cs`
+
+- [ ] **Step 1: Add the field**
+
+Open `KeyStats.Windows/KeyStats/Models/AppSettings.cs`. Add this property at the bottom of the class (after the existing `MainWindowHeight` property), before the closing `}`:
+
+```csharp
+    [JsonPropertyName("languagePreference")]
+    public string LanguagePreference { get; set; } = "system";  // "system" | "zh-Hans" | "en"
+```
+
+- [ ] **Step 2: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Models/AppSettings.cs
+git commit -m "feat(i18n): add LanguagePreference to AppSettings"
+```
+
+---
+
+## Task 4: Wire LocalizationManager into App startup
+
+Apply the user's language preference at the very top of `OnStartup`, before any UI is constructed. Add mutex retry (1-2 attempts at 500ms) so a restart-triggered relaunch doesn't fail when the old process is still in `OnExit`. Replace the hardcoded "按键统计已在运行中" with English fallback (mutex failure is a tiny edge case, English is fine).
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/App.xaml.cs` (lines ~64-75 specifically; see existing `OnStartup`)
+
+- [ ] **Step 1: Replace the mutex check block in `OnStartup`**
+
+In `App.xaml.cs::OnStartup`, locate the existing block (currently around lines 65-77 — search for `"KeyStats_SingleInstance"`):
+
+```csharp
+            Console.WriteLine("KeyStats starting...");
+
+            // Ensure single instance
+            var mutex = new System.Threading.Mutex(true, "KeyStats_SingleInstance", out bool createdNew);
+            if (!createdNew)
+            {
+                mutex.Dispose();
+                MessageBox.Show("按键统计已在运行中。", "按键统计", MessageBoxButton.OK, MessageBoxImage.Information);
+                Shutdown();
+                return;
+            }
+            _singleInstanceMutex = mutex;
+```
+
+Replace it with:
+
+```csharp
+            Console.WriteLine("KeyStats starting...");
+
+            // Apply language preference BEFORE any UI loads.
+            // StatsManager.Instance triggers settings.json load on first access.
+            var preliminarySettings = StatsManager.Instance.Settings;
+            LocalizationManager.ApplyAtStartup(preliminarySettings.LanguagePreference);
+
+            // Ensure single instance — retry up to 3 attempts (500ms apart) so a
+            // language-switch relaunch doesn't lose the race against the old
+            // process's OnExit cleanup.
+            System.Threading.Mutex? mutex = null;
+            bool createdNew = false;
+            for (int attempt = 0; attempt < 3; attempt++)
+            {
+                mutex = new System.Threading.Mutex(true, "KeyStats_SingleInstance", out createdNew);
+                if (createdNew) break;
+                mutex.Dispose();
+                mutex = null;
+                System.Threading.Thread.Sleep(500);
+            }
+
+            if (!createdNew)
+            {
+                // English fallback — keep simple and reliable for this edge case.
+                MessageBox.Show("KeyStats is already running.", "KeyStats",
+                                MessageBoxButton.OK, MessageBoxImage.Information);
+                Shutdown();
+                return;
+            }
+            _singleInstanceMutex = mutex;
+```
+
+- [ ] **Step 2: Update the catch block's hardcoded Chinese**
+
+Locate the catch block at the end of `OnStartup` (currently around lines 108-113):
+
+```csharp
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error during startup: {ex}");
+            MessageBox.Show($"启动错误: {ex.Message}", "按键统计错误", MessageBoxButton.OK, MessageBoxImage.Error);
+            Shutdown();
+        }
+```
+
+Replace with:
+
+```csharp
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error during startup: {ex}");
+            MessageBox.Show(string.Format(KeyStats.Properties.Strings.Error_StartupFailedFormat, ex.Message),
+                            KeyStats.Properties.Strings.Error_AppErrorTitle,
+                            MessageBoxButton.OK, MessageBoxImage.Error);
+            Shutdown();
+        }
+```
+
+- [ ] **Step 3: Add `using` if needed**
+
+Confirm `App.xaml.cs` already has `using KeyStats.Helpers;` (it does — see existing imports). Don't add `using KeyStats.Properties;` — fully qualify `KeyStats.Properties.Strings` to avoid colliding with the existing `using System.Windows.Controls.Primitives;` (no actual collision, but explicit qualification is clearer for a few call sites; later tasks will add the using). For this task, fully qualify.
+
+- [ ] **Step 4: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Smoke test — startup language detection**
+
+Run the app and observe (this only verifies plumbing; the UI is still hardcoded Chinese, so the visual check is just "does it launch without crashing"):
+- App launches normally on whatever Windows machine is being tested.
+- No exceptions in Debug console.
+- Tray icon appears.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/App.xaml.cs
+git commit -m "feat(i18n): apply LocalizationManager at startup; add mutex retry"
+```
+
+---
+
+## Task 5: Migrate App.xaml.cs tray menu, toasts, and shortcut text
+
+App.xaml.cs has 39 hardcoded Chinese occurrences spread across:
+- Tray context menu items (5)
+- Mutex error already done in Task 4
+- Catch block already done in Task 4
+- Import / export toast titles + bodies (8)
+- Single-instance mutex shortcut description (1)
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/App.xaml.cs`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.cs`
+
+- [ ] **Step 1: Add keys to `Strings.resx`**
+
+Add these `<data>` elements to `Strings.resx`:
+
+```xml
+  <data name="Tray_OpenMainWindow" xml:space="preserve"><value>Open Main Window</value></data>
+  <data name="Tray_Settings" xml:space="preserve"><value>Settings</value></data>
+  <data name="Tray_StartAtLogin" xml:space="preserve"><value>Start at Login</value></data>
+  <data name="Tray_KeyHistory" xml:space="preserve"><value>Key History</value></data>
+  <data name="Tray_Quit" xml:space="preserve"><value>Quit</value></data>
+
+  <data name="Toast_ExportSuccess_Title" xml:space="preserve"><value>Export Successful</value></data>
+  <data name="Toast_ExportSuccess_BodyFormat" xml:space="preserve"><value>Data saved to {0}</value></data>
+  <data name="Toast_ExportFailed_Title" xml:space="preserve"><value>Export Failed</value></data>
+  <data name="Toast_ExportFailed_BodyFormat" xml:space="preserve"><value>Could not export data: {0}</value></data>
+  <data name="Toast_ImportSuccess_Title" xml:space="preserve"><value>Import Successful</value></data>
+  <data name="Toast_ImportSuccess_BodyFormat" xml:space="preserve"><value>Statistics imported via {0}: {1}</value></data>
+  <data name="Toast_ImportFailed_Title" xml:space="preserve"><value>Import Failed</value></data>
+  <data name="Toast_ImportFailed_BodyFormat" xml:space="preserve"><value>Could not import data: {0}</value></data>
+  <data name="ImportMode_Overwrite" xml:space="preserve"><value>Overwrite</value></data>
+  <data name="ImportMode_Merge" xml:space="preserve"><value>Merge</value></data>
+
+  <data name="Shortcut_Description" xml:space="preserve"><value>KeyStats</value></data>
+
+  <data name="Dialog_ExportTitle" xml:space="preserve"><value>Export Data</value></data>
+  <data name="Dialog_ImportTitle" xml:space="preserve"><value>Import Data</value></data>
+  <data name="Dialog_JsonFilter" xml:space="preserve"><value>JSON Files (*.json)|*.json|All Files (*.*)|*.*</value></data>
+```
+
+- [ ] **Step 2: Add matching keys to `Strings.zh-Hans.resx`**
+
+```xml
+  <data name="Tray_OpenMainWindow" xml:space="preserve"><value>打开主界面</value></data>
+  <data name="Tray_Settings" xml:space="preserve"><value>设置</value></data>
+  <data name="Tray_StartAtLogin" xml:space="preserve"><value>开机启动</value></data>
+  <data name="Tray_KeyHistory" xml:space="preserve"><value>历史按键统计</value></data>
+  <data name="Tray_Quit" xml:space="preserve"><value>退出</value></data>
+
+  <data name="Toast_ExportSuccess_Title" xml:space="preserve"><value>导出成功</value></data>
+  <data name="Toast_ExportSuccess_BodyFormat" xml:space="preserve"><value>数据已保存到 {0}</value></data>
+  <data name="Toast_ExportFailed_Title" xml:space="preserve"><value>导出失败</value></data>
+  <data name="Toast_ExportFailed_BodyFormat" xml:space="preserve"><value>无法导出数据：{0}</value></data>
+  <data name="Toast_ImportSuccess_Title" xml:space="preserve"><value>导入成功</value></data>
+  <data name="Toast_ImportSuccess_BodyFormat" xml:space="preserve"><value>已{0}导入统计数据：{1}</value></data>
+  <data name="Toast_ImportFailed_Title" xml:space="preserve"><value>导入失败</value></data>
+  <data name="Toast_ImportFailed_BodyFormat" xml:space="preserve"><value>无法导入数据：{0}</value></data>
+  <data name="ImportMode_Overwrite" xml:space="preserve"><value>覆盖</value></data>
+  <data name="ImportMode_Merge" xml:space="preserve"><value>合并</value></data>
+
+  <data name="Shortcut_Description" xml:space="preserve"><value>按键统计</value></data>
+
+  <data name="Dialog_ExportTitle" xml:space="preserve"><value>导出数据</value></data>
+  <data name="Dialog_ImportTitle" xml:space="preserve"><value>导入数据</value></data>
+  <data name="Dialog_JsonFilter" xml:space="preserve"><value>JSON 文件 (*.json)|*.json|所有文件 (*.*)|*.*</value></data>
+```
+
+- [ ] **Step 3: Add properties to `Strings.cs`**
+
+Append to the Strings class, before the closing `}`:
+
+```csharp
+    public static string Tray_OpenMainWindow => Get(nameof(Tray_OpenMainWindow));
+    public static string Tray_Settings => Get(nameof(Tray_Settings));
+    public static string Tray_StartAtLogin => Get(nameof(Tray_StartAtLogin));
+    public static string Tray_KeyHistory => Get(nameof(Tray_KeyHistory));
+    public static string Tray_Quit => Get(nameof(Tray_Quit));
+
+    public static string Toast_ExportSuccess_Title => Get(nameof(Toast_ExportSuccess_Title));
+    public static string Toast_ExportSuccess_BodyFormat => Get(nameof(Toast_ExportSuccess_BodyFormat));
+    public static string Toast_ExportFailed_Title => Get(nameof(Toast_ExportFailed_Title));
+    public static string Toast_ExportFailed_BodyFormat => Get(nameof(Toast_ExportFailed_BodyFormat));
+    public static string Toast_ImportSuccess_Title => Get(nameof(Toast_ImportSuccess_Title));
+    public static string Toast_ImportSuccess_BodyFormat => Get(nameof(Toast_ImportSuccess_BodyFormat));
+    public static string Toast_ImportFailed_Title => Get(nameof(Toast_ImportFailed_Title));
+    public static string Toast_ImportFailed_BodyFormat => Get(nameof(Toast_ImportFailed_BodyFormat));
+    public static string ImportMode_Overwrite => Get(nameof(ImportMode_Overwrite));
+    public static string ImportMode_Merge => Get(nameof(ImportMode_Merge));
+
+    public static string Shortcut_Description => Get(nameof(Shortcut_Description));
+
+    public static string Dialog_ExportTitle => Get(nameof(Dialog_ExportTitle));
+    public static string Dialog_ImportTitle => Get(nameof(Dialog_ImportTitle));
+    public static string Dialog_JsonFilter => Get(nameof(Dialog_JsonFilter));
+```
+
+- [ ] **Step 4: Migrate the tray menu in `CreateContextMenu`**
+
+In `App.xaml.cs::CreateContextMenu`, replace the 5 hardcoded `Header` strings:
+
+```csharp
+        var openMainWindowItem = new System.Windows.Controls.MenuItem { Header = "打开主界面" };
+        // ...
+        var settingsItem = new System.Windows.Controls.MenuItem { Header = "设置" };
+        // ...
+        var startupItem = new System.Windows.Controls.MenuItem
+        {
+            Header = "开机启动",
+            // ...
+        };
+        // ...
+        var keyHistoryItem = new System.Windows.Controls.MenuItem { Header = "历史按键统计" };
+        // ...
+        var quitItem = new System.Windows.Controls.MenuItem { Header = "退出" };
+```
+
+becomes:
+
+```csharp
+        var openMainWindowItem = new System.Windows.Controls.MenuItem { Header = KeyStats.Properties.Strings.Tray_OpenMainWindow };
+        // ...
+        var settingsItem = new System.Windows.Controls.MenuItem { Header = KeyStats.Properties.Strings.Tray_Settings };
+        // ...
+        var startupItem = new System.Windows.Controls.MenuItem
+        {
+            Header = KeyStats.Properties.Strings.Tray_StartAtLogin,
+            // ...
+        };
+        // ...
+        var keyHistoryItem = new System.Windows.Controls.MenuItem { Header = KeyStats.Properties.Strings.Tray_KeyHistory };
+        // ...
+        var quitItem = new System.Windows.Controls.MenuItem { Header = KeyStats.Properties.Strings.Tray_Quit };
+```
+
+- [ ] **Step 5: Migrate `ExportData` and `ImportData` toasts and dialog titles**
+
+In `App.xaml.cs::ExportData`, the `SaveFileDialog` block:
+
+```csharp
+            var dialog = new SaveFileDialog
+            {
+                Title = "导出数据",
+                Filter = "JSON 文件 (*.json)|*.json|所有文件 (*.*)|*.*",
+                // ...
+            };
+```
+
+becomes:
+
+```csharp
+            var dialog = new SaveFileDialog
+            {
+                Title = KeyStats.Properties.Strings.Dialog_ExportTitle,
+                Filter = KeyStats.Properties.Strings.Dialog_JsonFilter,
+                // ...
+            };
+```
+
+The export success toast:
+
+```csharp
+                new ToastContentBuilder()
+                    .AddText("导出成功")
+                    .AddText($"数据已保存到 {Path.GetFileName(dialog.FileName)}")
+                    .Show();
+```
+
+becomes:
+
+```csharp
+                new ToastContentBuilder()
+                    .AddText(KeyStats.Properties.Strings.Toast_ExportSuccess_Title)
+                    .AddText(string.Format(KeyStats.Properties.Strings.Toast_ExportSuccess_BodyFormat, Path.GetFileName(dialog.FileName)))
+                    .Show();
+```
+
+The export failure toast:
+
+```csharp
+            new ToastContentBuilder()
+                .AddText("导出失败")
+                .AddText($"无法导出数据：{ex.Message}")
+                .Show();
+```
+
+becomes:
+
+```csharp
+            new ToastContentBuilder()
+                .AddText(KeyStats.Properties.Strings.Toast_ExportFailed_Title)
+                .AddText(string.Format(KeyStats.Properties.Strings.Toast_ExportFailed_BodyFormat, ex.Message))
+                .Show();
+```
+
+In `ImportData`, dialog title:
+
+```csharp
+                Title = "导入数据",
+                Filter = "JSON 文件 (*.json)|*.json|所有文件 (*.*)|*.*",
+```
+
+becomes:
+
+```csharp
+                Title = KeyStats.Properties.Strings.Dialog_ImportTitle,
+                Filter = KeyStats.Properties.Strings.Dialog_JsonFilter,
+```
+
+The import success block currently has:
+
+```csharp
+                var modeLabel = mode == StatsManager.ImportMode.Overwrite ? "覆盖" : "合并";
+                new ToastContentBuilder()
+                    .AddText("导入成功")
+                    .AddText($"已{modeLabel}导入统计数据：{Path.GetFileName(selectedFile)}")
+                    .Show();
+```
+
+becomes:
+
+```csharp
+                var modeLabel = mode == StatsManager.ImportMode.Overwrite
+                    ? KeyStats.Properties.Strings.ImportMode_Overwrite
+                    : KeyStats.Properties.Strings.ImportMode_Merge;
+                new ToastContentBuilder()
+                    .AddText(KeyStats.Properties.Strings.Toast_ImportSuccess_Title)
+                    .AddText(string.Format(KeyStats.Properties.Strings.Toast_ImportSuccess_BodyFormat, modeLabel, Path.GetFileName(selectedFile)))
+                    .Show();
+```
+
+The import failure toast:
+
+```csharp
+            new ToastContentBuilder()
+                .AddText("导入失败")
+                .AddText($"无法导入数据：{ex.Message}")
+                .Show();
+```
+
+becomes:
+
+```csharp
+            new ToastContentBuilder()
+                .AddText(KeyStats.Properties.Strings.Toast_ImportFailed_Title)
+                .AddText(string.Format(KeyStats.Properties.Strings.Toast_ImportFailed_BodyFormat, ex.Message))
+                .Show();
+```
+
+- [ ] **Step 6: Migrate the start-menu shortcut description in `EnsureStartMenuShortcut`**
+
+```csharp
+            shortcut.Description = "KeyStats";
+```
+
+becomes:
+
+```csharp
+            shortcut.Description = KeyStats.Properties.Strings.Shortcut_Description;
+```
+
+> Note: the underlying value in both languages happens to be similar, but Chinese expands to "按键统计" — translation is consistent with rest of UI.
+
+- [ ] **Step 7: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+Expected: build succeeds. Any missed reference (e.g., a typo'd key) shows up as a `CS0117` "does not contain a definition for…" error.
+
+- [ ] **Step 8: Smoke test (Windows reviewer or note it deferred)**
+
+Tray menu and toasts (this task does NOT yet add the Settings UI for switching languages, so verify in current detected language only):
+- Tray right-click → 5 menu items show in zh-Hans (or English if running on English-system test machine).
+- File → Export → toast appears with correct title/body.
+- File → Import → JSON dialog opens.
+
+If unable to test on Windows from current host, mark in commit body: `(Smoke gate deferred to Windows reviewer)`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/App.xaml.cs
+git commit -m "feat(i18n): migrate App.xaml.cs tray menu, toasts, dialogs"
+```
+
+---
+
+## Task 6: Add Settings Language card + restart flow
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml`
+- Modify: `KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.cs`
+
+This task adds the Language UI BEFORE migrating SettingsWindow's existing strings (Task 7). That way you can verify the restart flow first, then migrate the rest of the window.
+
+- [ ] **Step 1: Add keys to both `.resx` files**
+
+`Strings.resx`:
+
+```xml
+  <data name="Settings_Language" xml:space="preserve"><value>Language</value></data>
+  <data name="Settings_LanguageDescription" xml:space="preserve"><value>Display language for the app interface</value></data>
+  <data name="Settings_Language_System" xml:space="preserve"><value>System</value></data>
+  <data name="Language_RestartPromptTitle" xml:space="preserve"><value>Restart Required</value></data>
+  <data name="Language_RestartPromptMessage" xml:space="preserve"><value>KeyStats needs to restart to apply the new language. Restart now?</value></data>
+```
+
+`Strings.zh-Hans.resx`:
+
+```xml
+  <data name="Settings_Language" xml:space="preserve"><value>语言</value></data>
+  <data name="Settings_LanguageDescription" xml:space="preserve"><value>应用界面显示语言</value></data>
+  <data name="Settings_Language_System" xml:space="preserve"><value>跟随系统</value></data>
+  <data name="Language_RestartPromptTitle" xml:space="preserve"><value>需要重启</value></data>
+  <data name="Language_RestartPromptMessage" xml:space="preserve"><value>需要重启 KeyStats 才能切换语言。是否立即重启？</value></data>
+```
+
+- [ ] **Step 2: Add to `Strings.cs`**
+
+```csharp
+    public static string Settings_Language => Get(nameof(Settings_Language));
+    public static string Settings_LanguageDescription => Get(nameof(Settings_LanguageDescription));
+    public static string Settings_Language_System => Get(nameof(Settings_Language_System));
+    public static string Language_RestartPromptTitle => Get(nameof(Language_RestartPromptTitle));
+    public static string Language_RestartPromptMessage => Get(nameof(Language_RestartPromptMessage));
+```
+
+- [ ] **Step 3: Add the Language card to `SettingsWindow.xaml`**
+
+In `SettingsWindow.xaml`, add the namespace declaration `xmlns:p="clr-namespace:KeyStats.Properties"` to the `<Window>` element if not already present. Then add a new `<Border>` block AFTER the existing "距离校准" border (which currently has the comment-equivalent — look for `Click="MouseCalibration_Click"`) and BEFORE the `<TextBlock x:Name="VersionTextBlock"`:
+
+```xml
+        <Border Style="{DynamicResource CardBorder}" Margin="0,0,0,4" Padding="14,12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="{x:Static p:Strings.Settings_Language}"
+                               FontSize="13" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextPrimaryBrush}"/>
+                    <TextBlock Text="{x:Static p:Strings.Settings_LanguageDescription}"
+                               FontSize="12"
+                               Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,4,0,0"/>
+                </StackPanel>
+                <ComboBox Grid.Column="1"
+                          x:Name="LanguageComboBox"
+                          MinWidth="140"
+                          SelectionChanged="LanguageComboBox_SelectionChanged"
+                          Loaded="LanguageComboBox_Loaded">
+                    <ComboBoxItem Content="{x:Static p:Strings.Settings_Language_System}" Tag="system"/>
+                    <ComboBoxItem Content="中文" Tag="zh-Hans"/>
+                    <ComboBoxItem Content="English" Tag="en"/>
+                </ComboBox>
+            </Grid>
+        </Border>
+```
+
+> "中文" and "English" are intentionally NOT translated — they're self-referential labels.
+
+- [ ] **Step 4: Add code-behind for the Language ComboBox**
+
+In `SettingsWindow.xaml.cs`, add at the top of the file:
+
+```csharp
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using KeyStats.Services;
+```
+
+(Confirm these are present; only add the missing ones.)
+
+Add these private fields and methods inside the `SettingsWindow` class:
+
+```csharp
+    private bool _isInitializingLanguage = true;
+
+    private void LanguageComboBox_Loaded(object sender, RoutedEventArgs e)
+    {
+        var current = StatsManager.Instance.Settings.LanguagePreference ?? "system";
+        LanguageComboBox.SelectedItem = LanguageComboBox.Items
+            .Cast<ComboBoxItem>()
+            .FirstOrDefault(i => (string)i.Tag == current)
+            ?? LanguageComboBox.Items[0];
+        _isInitializingLanguage = false;
+    }
+
+    private void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isInitializingLanguage) return;
+
+        var newPref = (string?)((ComboBoxItem?)LanguageComboBox.SelectedItem)?.Tag;
+        if (string.IsNullOrEmpty(newPref)) return;
+
+        var oldPref = StatsManager.Instance.Settings.LanguagePreference ?? "system";
+        if (newPref == oldPref) return;
+
+        var result = MessageBox.Show(
+            KeyStats.Properties.Strings.Language_RestartPromptMessage,
+            KeyStats.Properties.Strings.Language_RestartPromptTitle,
+            MessageBoxButton.OKCancel,
+            MessageBoxImage.Information);
+
+        if (result == MessageBoxResult.OK)
+        {
+            StatsManager.Instance.Settings.LanguagePreference = newPref;
+            StatsManager.Instance.SaveSettings();
+            RestartApp();
+        }
+        else
+        {
+            // User cancelled — revert ComboBox to the previously persisted value.
+            _isInitializingLanguage = true;
+            LanguageComboBox.SelectedItem = LanguageComboBox.Items
+                .Cast<ComboBoxItem>()
+                .FirstOrDefault(i => (string)i.Tag == oldPref);
+            _isInitializingLanguage = false;
+        }
+    }
+
+    private static void RestartApp()
+    {
+        try
+        {
+            var exePath = Process.GetCurrentProcess().MainModule?.FileName;
+            if (!string.IsNullOrEmpty(exePath))
+            {
+                Process.Start(exePath);
+            }
+        }
+        catch
+        {
+            // If relaunch fails, the user will simply have to start the app manually.
+        }
+        Application.Current.Shutdown();
+    }
+```
+
+- [ ] **Step 5: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 6: Smoke test (Windows reviewer)**
+
+1. Launch app. Open Settings. Verify the new "Language / 语言" card appears at the bottom (above the version text).
+2. ComboBox shows three options: System (translated), 中文, English.
+3. The current selection matches `settings.json` (default `"system"` → first option).
+4. Change selection to a different value → restart prompt appears with appropriate language → click OK → app exits and relaunches → settings.json now has new value → on relaunch, ComboBox reflects the new selection (UI is still mostly Chinese hardcoded; that's expected, fixed in Task 7+).
+5. Change selection again → prompt appears → click Cancel → ComboBox snaps back to previous value, no restart.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml.cs
+git commit -m "feat(i18n): add Language settings card with restart flow"
+```
+
+---
+
+## Task 7: Migrate SettingsWindow existing strings
+
+Migrate the rest of `SettingsWindow.xaml` (window title, header, three existing cards: data import/export, notifications, calibration) and the GitHub button tooltip. The Language card from Task 6 is already migrated.
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.cs`
+
+- [ ] **Step 1: Add keys to both `.resx` files**
+
+`Strings.resx`:
+
+```xml
+  <data name="Settings_WindowTitle" xml:space="preserve"><value>Settings - KeyStats</value></data>
+  <data name="Settings_HeaderTitle" xml:space="preserve"><value>Settings</value></data>
+  <data name="Settings_HeaderSubtitle" xml:space="preserve"><value>Manage import/export and notification settings here</value></data>
+  <data name="Settings_GitHubTooltip" xml:space="preserve"><value>Open GitHub repository</value></data>
+  <data name="Settings_DataImportExport" xml:space="preserve"><value>Data Import / Export</value></data>
+  <data name="Settings_DataImportExportDesc" xml:space="preserve"><value>Import or export statistics from JSON</value></data>
+  <data name="Settings_Notifications" xml:space="preserve"><value>Notifications</value></data>
+  <data name="Settings_NotificationsDesc" xml:space="preserve"><value>Configure key/click threshold notifications</value></data>
+  <data name="Settings_DistanceCalibration" xml:space="preserve"><value>Distance Calibration</value></data>
+  <data name="Settings_DistanceCalibrationDesc" xml:space="preserve"><value>Calibrate the mouse movement coefficient</value></data>
+```
+
+`Strings.zh-Hans.resx`:
+
+```xml
+  <data name="Settings_WindowTitle" xml:space="preserve"><value>设置 - KeyStats</value></data>
+  <data name="Settings_HeaderTitle" xml:space="preserve"><value>设置</value></data>
+  <data name="Settings_HeaderSubtitle" xml:space="preserve"><value>在这里管理导入导出与通知设置</value></data>
+  <data name="Settings_GitHubTooltip" xml:space="preserve"><value>打开 GitHub 仓库</value></data>
+  <data name="Settings_DataImportExport" xml:space="preserve"><value>数据导入 / 导出</value></data>
+  <data name="Settings_DataImportExportDesc" xml:space="preserve"><value>从 JSON 导入或导出统计数据</value></data>
+  <data name="Settings_Notifications" xml:space="preserve"><value>通知设置</value></data>
+  <data name="Settings_NotificationsDesc" xml:space="preserve"><value>设置按键/点击阈值通知</value></data>
+  <data name="Settings_DistanceCalibration" xml:space="preserve"><value>距离校准</value></data>
+  <data name="Settings_DistanceCalibrationDesc" xml:space="preserve"><value>校准鼠标移动距离系数</value></data>
+```
+
+- [ ] **Step 2: Add to `Strings.cs`**
+
+```csharp
+    public static string Settings_WindowTitle => Get(nameof(Settings_WindowTitle));
+    public static string Settings_HeaderTitle => Get(nameof(Settings_HeaderTitle));
+    public static string Settings_HeaderSubtitle => Get(nameof(Settings_HeaderSubtitle));
+    public static string Settings_GitHubTooltip => Get(nameof(Settings_GitHubTooltip));
+    public static string Settings_DataImportExport => Get(nameof(Settings_DataImportExport));
+    public static string Settings_DataImportExportDesc => Get(nameof(Settings_DataImportExportDesc));
+    public static string Settings_Notifications => Get(nameof(Settings_Notifications));
+    public static string Settings_NotificationsDesc => Get(nameof(Settings_NotificationsDesc));
+    public static string Settings_DistanceCalibration => Get(nameof(Settings_DistanceCalibration));
+    public static string Settings_DistanceCalibrationDesc => Get(nameof(Settings_DistanceCalibrationDesc));
+```
+
+- [ ] **Step 3: Migrate `SettingsWindow.xaml`**
+
+Replace each hardcoded value as follows.
+
+`Title="设置 - KeyStats"` → `Title="{x:Static p:Strings.Settings_WindowTitle}"`
+
+`<TextBlock Text="设置" FontSize="16" FontWeight="SemiBold"` → `<TextBlock Text="{x:Static p:Strings.Settings_HeaderTitle}" FontSize="16" FontWeight="SemiBold"`
+
+`ToolTip="打开 GitHub 仓库"` → `ToolTip="{x:Static p:Strings.Settings_GitHubTooltip}"`
+
+`<TextBlock Text="在这里管理导入导出与通知设置"` → `<TextBlock Text="{x:Static p:Strings.Settings_HeaderSubtitle}"`
+
+`<TextBlock Text="数据导入 / 导出" FontSize="13"` → `<TextBlock Text="{x:Static p:Strings.Settings_DataImportExport}" FontSize="13"`
+
+`<TextBlock Text="从 JSON 导入或导出统计数据"` → `<TextBlock Text="{x:Static p:Strings.Settings_DataImportExportDesc}"`
+
+`<Button Content="导入"` → `<Button Content="{x:Static p:Strings.Common_Import}"`
+
+`<Button Content="导出"` → `<Button Content="{x:Static p:Strings.Common_Export}"`
+
+`<TextBlock Text="通知设置" FontSize="13"` → `<TextBlock Text="{x:Static p:Strings.Settings_Notifications}" FontSize="13"`
+
+`<TextBlock Text="设置按键/点击阈值通知"` → `<TextBlock Text="{x:Static p:Strings.Settings_NotificationsDesc}"`
+
+`<Button Grid.Column="1" Content="打开"` (the notification one) → `<Button Grid.Column="1" Content="{x:Static p:Strings.Common_Open}"`
+
+`<TextBlock Text="距离校准" FontSize="13"` → `<TextBlock Text="{x:Static p:Strings.Settings_DistanceCalibration}" FontSize="13"`
+
+`<TextBlock Text="校准鼠标移动距离系数"` → `<TextBlock Text="{x:Static p:Strings.Settings_DistanceCalibrationDesc}"`
+
+`<Button Grid.Column="1" Content="打开"` (the calibration one) → `<Button Grid.Column="1" Content="{x:Static p:Strings.Common_Open}"`
+
+- [ ] **Step 4: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Smoke test (Windows reviewer)**
+
+Open Settings. Verify all labels and buttons render correctly in BOTH languages (use the new Language card to switch and observe). Title bar, header, three cards, GitHub tooltip, all buttons.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/Views/SettingsWindow.xaml
+git commit -m "feat(i18n): migrate SettingsWindow existing strings"
+```
+
+---
+
+## Task 8: Migrate StatsPopupWindow
+
+The largest file. 27 strings in XAML + 34 in code-behind. The code-behind strings are mostly in formatting strings for tooltips and chart labels.
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/Views/StatsPopupWindow.xaml`
+- Modify: `KeyStats.Windows/KeyStats/Views/StatsPopupWindow.xaml.cs`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.cs`
+
+> If this task is too large to land in one commit, split into 8a (XAML) and 8b (code-behind). The keys/translations below cover both.
+
+- [ ] **Step 1: Add keys to both `.resx` files**
+
+`Strings.resx`:
+
+```xml
+  <!-- Stats popup XAML -->
+  <data name="Stats_TodayHeader" xml:space="preserve"><value>Today's Stats</value></data>
+  <data name="Stats_PeakKpsLabel" xml:space="preserve"><value>Peak KPS</value></data>
+  <data name="Stats_PeakCpsLabel" xml:space="preserve"><value>Peak CPS</value></data>
+  <data name="Stats_KeyPresses" xml:space="preserve"><value>Key Presses</value></data>
+  <data name="Stats_MouseClicks" xml:space="preserve"><value>Mouse Clicks</value></data>
+  <data name="Stats_MouseClickDetail" xml:space="preserve"><value>Click Breakdown</value></data>
+  <data name="Click_Left" xml:space="preserve"><value>Left</value></data>
+  <data name="Click_Middle" xml:space="preserve"><value>Middle</value></data>
+  <data name="Click_Right" xml:space="preserve"><value>Right</value></data>
+  <data name="Click_Back" xml:space="preserve"><value>Back</value></data>
+  <data name="Click_Forward" xml:space="preserve"><value>Forward</value></data>
+  <data name="Stats_MouseDistance" xml:space="preserve"><value>Mouse Distance</value></data>
+  <data name="Stats_ScrollDistance" xml:space="preserve"><value>Scroll Distance</value></data>
+  <data name="Stats_KeyBreakdown" xml:space="preserve"><value>Key Distribution</value></data>
+  <data name="Stats_KeyboardHeatmap" xml:space="preserve"><value>Keyboard Heatmap</value></data>
+  <data name="Stats_KeyHistory" xml:space="preserve"><value>Key History</value></data>
+  <data name="Stats_ActiveApps" xml:space="preserve"><value>Active Apps</value></data>
+  <data name="Stats_AppStatsDetail" xml:space="preserve"><value>App Stats Details</value></data>
+  <data name="Stats_HistoryHeader" xml:space="preserve"><value>History</value></data>
+  <data name="Chart_Line" xml:space="preserve"><value>Line</value></data>
+  <data name="Chart_Bar" xml:space="preserve"><value>Bar</value></data>
+  <data name="Range_7Days" xml:space="preserve"><value>7 days</value></data>
+  <data name="Range_30Days" xml:space="preserve"><value>30 days</value></data>
+  <data name="Metric_Clicks" xml:space="preserve"><value>Clicks</value></data>
+  <data name="Metric_Keys" xml:space="preserve"><value>Keys</value></data>
+  <data name="Metric_Move" xml:space="preserve"><value>Move</value></data>
+  <data name="Metric_Scroll" xml:space="preserve"><value>Scroll</value></data>
+  <data name="Stats_PeakKpsTooltipLabel" xml:space="preserve"><value>Peak Keys/sec (KPS)</value></data>
+  <data name="Stats_PeakCpsTooltipLabel" xml:space="preserve"><value>Peak Clicks/sec (CPS)</value></data>
+```
+
+`Strings.zh-Hans.resx`:
+
+```xml
+  <data name="Stats_TodayHeader" xml:space="preserve"><value>今日统计</value></data>
+  <data name="Stats_PeakKpsLabel" xml:space="preserve"><value>峰值 KPS</value></data>
+  <data name="Stats_PeakCpsLabel" xml:space="preserve"><value>峰值 CPS</value></data>
+  <data name="Stats_KeyPresses" xml:space="preserve"><value>按键次数</value></data>
+  <data name="Stats_MouseClicks" xml:space="preserve"><value>鼠标点击</value></data>
+  <data name="Stats_MouseClickDetail" xml:space="preserve"><value>鼠标点击明细</value></data>
+  <data name="Click_Left" xml:space="preserve"><value>左键</value></data>
+  <data name="Click_Middle" xml:space="preserve"><value>中键</value></data>
+  <data name="Click_Right" xml:space="preserve"><value>右键</value></data>
+  <data name="Click_Back" xml:space="preserve"><value>后退</value></data>
+  <data name="Click_Forward" xml:space="preserve"><value>前进</value></data>
+  <data name="Stats_MouseDistance" xml:space="preserve"><value>鼠标移动</value></data>
+  <data name="Stats_ScrollDistance" xml:space="preserve"><value>滚轮滚动</value></data>
+  <data name="Stats_KeyBreakdown" xml:space="preserve"><value>按键分布</value></data>
+  <data name="Stats_KeyboardHeatmap" xml:space="preserve"><value>键盘热力图</value></data>
+  <data name="Stats_KeyHistory" xml:space="preserve"><value>历史按键统计</value></data>
+  <data name="Stats_ActiveApps" xml:space="preserve"><value>活跃应用</value></data>
+  <data name="Stats_AppStatsDetail" xml:space="preserve"><value>应用统计详情</value></data>
+  <data name="Stats_HistoryHeader" xml:space="preserve"><value>历史记录</value></data>
+  <data name="Chart_Line" xml:space="preserve"><value>折线</value></data>
+  <data name="Chart_Bar" xml:space="preserve"><value>柱状</value></data>
+  <data name="Range_7Days" xml:space="preserve"><value>7天</value></data>
+  <data name="Range_30Days" xml:space="preserve"><value>30天</value></data>
+  <data name="Metric_Clicks" xml:space="preserve"><value>点击</value></data>
+  <data name="Metric_Keys" xml:space="preserve"><value>按键</value></data>
+  <data name="Metric_Move" xml:space="preserve"><value>移动</value></data>
+  <data name="Metric_Scroll" xml:space="preserve"><value>滚动</value></data>
+  <data name="Stats_PeakKpsTooltipLabel" xml:space="preserve"><value>峰值按键速度(KPS)</value></data>
+  <data name="Stats_PeakCpsTooltipLabel" xml:space="preserve"><value>峰值点击速度(CPS)</value></data>
+```
+
+- [ ] **Step 2: Add to `Strings.cs`**
+
+```csharp
+    public static string Stats_TodayHeader => Get(nameof(Stats_TodayHeader));
+    public static string Stats_PeakKpsLabel => Get(nameof(Stats_PeakKpsLabel));
+    public static string Stats_PeakCpsLabel => Get(nameof(Stats_PeakCpsLabel));
+    public static string Stats_KeyPresses => Get(nameof(Stats_KeyPresses));
+    public static string Stats_MouseClicks => Get(nameof(Stats_MouseClicks));
+    public static string Stats_MouseClickDetail => Get(nameof(Stats_MouseClickDetail));
+    public static string Click_Left => Get(nameof(Click_Left));
+    public static string Click_Middle => Get(nameof(Click_Middle));
+    public static string Click_Right => Get(nameof(Click_Right));
+    public static string Click_Back => Get(nameof(Click_Back));
+    public static string Click_Forward => Get(nameof(Click_Forward));
+    public static string Stats_MouseDistance => Get(nameof(Stats_MouseDistance));
+    public static string Stats_ScrollDistance => Get(nameof(Stats_ScrollDistance));
+    public static string Stats_KeyBreakdown => Get(nameof(Stats_KeyBreakdown));
+    public static string Stats_KeyboardHeatmap => Get(nameof(Stats_KeyboardHeatmap));
+    public static string Stats_KeyHistory => Get(nameof(Stats_KeyHistory));
+    public static string Stats_ActiveApps => Get(nameof(Stats_ActiveApps));
+    public static string Stats_AppStatsDetail => Get(nameof(Stats_AppStatsDetail));
+    public static string Stats_HistoryHeader => Get(nameof(Stats_HistoryHeader));
+    public static string Chart_Line => Get(nameof(Chart_Line));
+    public static string Chart_Bar => Get(nameof(Chart_Bar));
+    public static string Range_7Days => Get(nameof(Range_7Days));
+    public static string Range_30Days => Get(nameof(Range_30Days));
+    public static string Metric_Clicks => Get(nameof(Metric_Clicks));
+    public static string Metric_Keys => Get(nameof(Metric_Keys));
+    public static string Metric_Move => Get(nameof(Metric_Move));
+    public static string Metric_Scroll => Get(nameof(Metric_Scroll));
+    public static string Stats_PeakKpsTooltipLabel => Get(nameof(Stats_PeakKpsTooltipLabel));
+    public static string Stats_PeakCpsTooltipLabel => Get(nameof(Stats_PeakCpsTooltipLabel));
+```
+
+- [ ] **Step 3: Migrate `StatsPopupWindow.xaml`**
+
+Add `xmlns:p="clr-namespace:KeyStats.Properties"` to the `<Window>` element.
+
+Replace each hardcoded literal:
+
+| Original | Replacement |
+|---|---|
+| `Text="今日统计"` | `Text="{x:Static p:Strings.Stats_TodayHeader}"` |
+| `Text="峰值按键速度(KPS)"` | `Text="{x:Static p:Strings.Stats_PeakKpsTooltipLabel}"` |
+| `Text="峰值点击速度(CPS)"` | `Text="{x:Static p:Strings.Stats_PeakCpsTooltipLabel}"` |
+| `Title="按键次数"` | `Title="{x:Static p:Strings.Stats_KeyPresses}"` |
+| `Title="鼠标点击"` | `Title="{x:Static p:Strings.Stats_MouseClicks}"` |
+| `Text="鼠标点击明细"` | `Text="{x:Static p:Strings.Stats_MouseClickDetail}"` |
+| `Text="左键"` | `Text="{x:Static p:Strings.Click_Left}"` |
+| `Text="中键"` | `Text="{x:Static p:Strings.Click_Middle}"` |
+| `Text="右键"` | `Text="{x:Static p:Strings.Click_Right}"` |
+| `Text="后退"` | `Text="{x:Static p:Strings.Click_Back}"` |
+| `Text="前进"` | `Text="{x:Static p:Strings.Click_Forward}"` |
+| `Title="鼠标移动"` | `Title="{x:Static p:Strings.Stats_MouseDistance}"` |
+| `Title="滚轮滚动"` | `Title="{x:Static p:Strings.Stats_ScrollDistance}"` |
+| `Text="按键分布"` | `Text="{x:Static p:Strings.Stats_KeyBreakdown}"` |
+| `Content="键盘热力图"` | `Content="{x:Static p:Strings.Stats_KeyboardHeatmap}"` |
+| `Content="历史按键统计"` | `Content="{x:Static p:Strings.Stats_KeyHistory}"` |
+| `Text="活跃应用"` | `Text="{x:Static p:Strings.Stats_ActiveApps}"` |
+| `Content="应用统计详情"` | `Content="{x:Static p:Strings.Stats_AppStatsDetail}"` |
+| `Text="历史记录"` | `Text="{x:Static p:Strings.Stats_HistoryHeader}"` |
+| `Text=" 折线"` | `Text="{x:Static p:Strings.Chart_Line}"` (drop the leading space — the `<TextBlock>` is in a `<StackPanel Orientation="Horizontal">` after an icon TextBlock; if visual spacing matters, set `Margin="2,0,0,0"` on this TextBlock instead) |
+| `Text=" 柱状"` | `Text="{x:Static p:Strings.Chart_Bar}"` (same spacing note) |
+| `Content="7天"` | `Content="{x:Static p:Strings.Range_7Days}"` |
+| `Content="30天"` | `Content="{x:Static p:Strings.Range_30Days}"` |
+| `Content="点击"` (Metric) | `Content="{x:Static p:Strings.Metric_Clicks}"` |
+| `Content="按键"` (Metric) | `Content="{x:Static p:Strings.Metric_Keys}"` |
+| `Content="移动"` (Metric) | `Content="{x:Static p:Strings.Metric_Move}"` |
+| `Content="滚动"` (Metric) | `Content="{x:Static p:Strings.Metric_Scroll}"` |
+
+> Title="KeyStats" stays as-is (app name, not localized).
+
+- [ ] **Step 4: Migrate `StatsPopupWindow.xaml.cs`**
+
+The 34 hits in this file are mostly Console.WriteLine logs and comments. Strategy:
+1. **Console logs:** convert to English (developer-facing, not localized).
+2. **String literal comparisons / format strings:** if user-visible (e.g., used as a Window.Title or in a MessageBox), translate via `Strings.*`. Otherwise leave as-is.
+
+Open `StatsPopupWindow.xaml.cs`. For each Chinese-containing line:
+
+- `Console.WriteLine($"显示统计弹窗: ...")` and similar → rewrite the string in English. Example: `Console.WriteLine($"Showing stats popup: ...")`
+- Comment lines (`// 中文注释`) → optionally translate to English while you're there, but not required.
+- Any `MessageBox.Show("...", "...", ...)` with Chinese → use `Strings.*` keys (add new keys if needed; copy the pattern from Task 5).
+
+Since this file is heavy on internal logging, expect the bulk of changes to be Console.WriteLine rewrites. After the changes, search the file for any remaining `[一-鿿]` characters and confirm only comments remain (and consider translating those too).
+
+- [ ] **Step 5: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 6: Smoke test (Windows reviewer)**
+
+Open the stats popup (left-click the tray icon). Verify ALL labels render correctly in both languages:
+- "Today's Stats / 今日统计" header
+- Peak KPS/CPS popout
+- Key Presses / Mouse Clicks cards
+- Click Breakdown (Left/Middle/Right + Back/Forward when 5-button mouse)
+- Mouse Distance / Scroll Distance cards
+- Key Distribution section + buttons (Keyboard Heatmap, Key History)
+- Active Apps section + button (App Stats Details)
+- History section + chart style toggle (Line/Bar)
+- Range chips (7 days / 30 days)
+- Metric chips (Clicks/Keys/Move/Scroll)
+- HistorySummary text (this is a binding to a ViewModel property — if it shows untranslated Chinese, that's expected; fixed in Task 14: ViewModels)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/Views/StatsPopupWindow.xaml KeyStats.Windows/KeyStats/Views/StatsPopupWindow.xaml.cs
+git commit -m "feat(i18n): migrate StatsPopupWindow strings"
+```
+
+---
+
+## Task 9: Migrate AppStatsWindow
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/Views/AppStatsWindow.xaml`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.cs`
+
+- [ ] **Step 1: Add keys to both `.resx` files**
+
+`Strings.resx`:
+
+```xml
+  <data name="AppStats_WindowTitle" xml:space="preserve"><value>App Stats</value></data>
+  <data name="AppStats_HeaderTitle" xml:space="preserve"><value>App Stats</value></data>
+  <data name="AppStats_HeaderSubtitle" xml:space="preserve"><value>Per-app keyboard/click/scroll stats; only aggregates are saved</value></data>
+  <data name="AppStats_RangeToday" xml:space="preserve"><value>Today</value></data>
+  <data name="AppStats_Range7Days" xml:space="preserve"><value>Last 7 days</value></data>
+  <data name="AppStats_Range30Days" xml:space="preserve"><value>Last 30 days</value></data>
+  <data name="AppStats_RangeAll" xml:space="preserve"><value>All</value></data>
+  <data name="AppStats_ColumnApp" xml:space="preserve"><value>App</value></data>
+```
+
+`Strings.zh-Hans.resx`:
+
+```xml
+  <data name="AppStats_WindowTitle" xml:space="preserve"><value>按应用统计</value></data>
+  <data name="AppStats_HeaderTitle" xml:space="preserve"><value>按应用统计</value></data>
+  <data name="AppStats_HeaderSubtitle" xml:space="preserve"><value>按应用统计键盘/点击/滚动，仅保存聚合数据</value></data>
+  <data name="AppStats_RangeToday" xml:space="preserve"><value>今天</value></data>
+  <data name="AppStats_Range7Days" xml:space="preserve"><value>过去7天</value></data>
+  <data name="AppStats_Range30Days" xml:space="preserve"><value>过去30天</value></data>
+  <data name="AppStats_RangeAll" xml:space="preserve"><value>全部</value></data>
+  <data name="AppStats_ColumnApp" xml:space="preserve"><value>应用</value></data>
+```
+
+- [ ] **Step 2: Add to `Strings.cs`**
+
+```csharp
+    public static string AppStats_WindowTitle => Get(nameof(AppStats_WindowTitle));
+    public static string AppStats_HeaderTitle => Get(nameof(AppStats_HeaderTitle));
+    public static string AppStats_HeaderSubtitle => Get(nameof(AppStats_HeaderSubtitle));
+    public static string AppStats_RangeToday => Get(nameof(AppStats_RangeToday));
+    public static string AppStats_Range7Days => Get(nameof(AppStats_Range7Days));
+    public static string AppStats_Range30Days => Get(nameof(AppStats_Range30Days));
+    public static string AppStats_RangeAll => Get(nameof(AppStats_RangeAll));
+    public static string AppStats_ColumnApp => Get(nameof(AppStats_ColumnApp));
+```
+
+- [ ] **Step 3: Migrate `AppStatsWindow.xaml`**
+
+Add `xmlns:p="clr-namespace:KeyStats.Properties"` to the `<Window>` element.
+
+| Original | Replacement |
+|---|---|
+| `Title="按应用统计"` | `Title="{x:Static p:Strings.AppStats_WindowTitle}"` |
+| `Text="按应用统计"` (header h1) | `Text="{x:Static p:Strings.AppStats_HeaderTitle}"` |
+| `Text="按应用统计键盘/点击/滚动，仅保存聚合数据"` | `Text="{x:Static p:Strings.AppStats_HeaderSubtitle}"` |
+| `Content="今天"` | `Content="{x:Static p:Strings.AppStats_RangeToday}"` |
+| `Content="过去7天"` | `Content="{x:Static p:Strings.AppStats_Range7Days}"` |
+| `Content="过去30天"` | `Content="{x:Static p:Strings.AppStats_Range30Days}"` |
+| `Content="全部"` | `Content="{x:Static p:Strings.AppStats_RangeAll}"` |
+| `Text="应用"` | `Text="{x:Static p:Strings.AppStats_ColumnApp}"` |
+
+> The `KeysHeader`, `ClicksHeader`, `ScrollHeader`, `SummaryText`, `EmptyText` are bindings to `AppStatsViewModel` — those will be migrated in Task 14 (ViewModels).
+
+- [ ] **Step 4: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+- [ ] **Step 5: Smoke test (Windows reviewer)**
+
+Open the App Stats window (right-click tray → "Open Main Window" → "Active Apps" → "App Stats Details" or wherever the entry is). Verify title, header, subtitle, four range chips, "App" column header.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/Views/AppStatsWindow.xaml
+git commit -m "feat(i18n): migrate AppStatsWindow strings"
+```
+
+---
+
+## Task 10: Migrate KeyboardHeatmapWindow
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/Views/KeyboardHeatmapWindow.xaml`
+- Modify: `KeyStats.Windows/KeyStats/Views/KeyboardHeatmapWindow.xaml.cs`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.cs`
+
+- [ ] **Step 1: Inspect file to enumerate strings**
+
+Open `KeyboardHeatmapWindow.xaml` and `.cs`. Note each Chinese string. Using `KeyStats/zh-Hans.lproj/Localizable.strings` as the macOS reference, the expected keys are:
+
+`Strings.resx`:
+
+```xml
+  <data name="Heatmap_WindowTitle" xml:space="preserve"><value>Keyboard Heatmap</value></data>
+  <data name="Heatmap_HeaderTitle" xml:space="preserve"><value>Keyboard Heatmap</value></data>
+  <data name="Heatmap_HeaderSubtitle" xml:space="preserve"><value>Full virtual keyboard view with daily key heat</value></data>
+  <data name="Heatmap_PrevDay" xml:space="preserve"><value>Previous day</value></data>
+  <data name="Heatmap_NextDay" xml:space="preserve"><value>Next day</value></data>
+  <data name="Heatmap_BackToToday" xml:space="preserve"><value>Today</value></data>
+  <data name="Heatmap_NoData" xml:space="preserve"><value>No keyboard activity for this day</value></data>
+  <data name="Heatmap_SummaryFormat" xml:space="preserve"><value>{0} key presses · {1} active keys</value></data>
+```
+
+`Strings.zh-Hans.resx`:
+
+```xml
+  <data name="Heatmap_WindowTitle" xml:space="preserve"><value>键盘热力图</value></data>
+  <data name="Heatmap_HeaderTitle" xml:space="preserve"><value>键盘热力图</value></data>
+  <data name="Heatmap_HeaderSubtitle" xml:space="preserve"><value>完整虚拟键盘视图，按天展示按键热度。</value></data>
+  <data name="Heatmap_PrevDay" xml:space="preserve"><value>上一天</value></data>
+  <data name="Heatmap_NextDay" xml:space="preserve"><value>下一天</value></data>
+  <data name="Heatmap_BackToToday" xml:space="preserve"><value>回到今天</value></data>
+  <data name="Heatmap_NoData" xml:space="preserve"><value>当天暂无键盘活动</value></data>
+  <data name="Heatmap_SummaryFormat" xml:space="preserve"><value>总计 {0} 次按键 · {1} 个活跃键</value></data>
+```
+
+- [ ] **Step 2: Add to `Strings.cs`**
+
+```csharp
+    public static string Heatmap_WindowTitle => Get(nameof(Heatmap_WindowTitle));
+    public static string Heatmap_HeaderTitle => Get(nameof(Heatmap_HeaderTitle));
+    public static string Heatmap_HeaderSubtitle => Get(nameof(Heatmap_HeaderSubtitle));
+    public static string Heatmap_PrevDay => Get(nameof(Heatmap_PrevDay));
+    public static string Heatmap_NextDay => Get(nameof(Heatmap_NextDay));
+    public static string Heatmap_BackToToday => Get(nameof(Heatmap_BackToToday));
+    public static string Heatmap_NoData => Get(nameof(Heatmap_NoData));
+    public static string Heatmap_SummaryFormat => Get(nameof(Heatmap_SummaryFormat));
+```
+
+- [ ] **Step 3: Migrate `KeyboardHeatmapWindow.xaml`**
+
+Add `xmlns:p="clr-namespace:KeyStats.Properties"`. Replace each Chinese string per the table from Step 1. For the summary `Format` string, if XAML directly binds it, replace with a binding to a ViewModel property (defer to ViewModel migration if applicable). For literal `Text="..."` matches, use `{x:Static p:Strings.<key>}`.
+
+For any inline format strings in code-behind (e.g., `$"总计 {x} 次按键 · {y} 个活跃键"`), replace with:
+
+```csharp
+string.Format(KeyStats.Properties.Strings.Heatmap_SummaryFormat, x, y)
+```
+
+- [ ] **Step 4: Migrate `KeyboardHeatmapWindow.xaml.cs`**
+
+Search for each `[一-鿿]` occurrence:
+- Console logs → English.
+- User-visible strings → `Strings.*` keys (use the keys from Step 1; add more if undersized).
+
+- [ ] **Step 5: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+- [ ] **Step 6: Smoke test (Windows reviewer)**
+
+Open Keyboard Heatmap window. Verify title, header, subtitle, navigation buttons (Previous/Today/Next), summary line, and empty state (cycle to a day with no activity).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/Views/KeyboardHeatmapWindow.xaml KeyStats.Windows/KeyStats/Views/KeyboardHeatmapWindow.xaml.cs
+git commit -m "feat(i18n): migrate KeyboardHeatmapWindow strings"
+```
+
+---
+
+## Task 11: Migrate KeyHistoryWindow
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/Views/KeyHistoryWindow.xaml`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.cs`
+
+- [ ] **Step 1: Inspect and enumerate strings**
+
+Open `KeyHistoryWindow.xaml`. The 9 Chinese hits cover:
+- Window Title
+- Section header(s)
+- Range labels (likely Yesterday / 7 days / 30 days)
+- Empty state
+- Possibly tooltip text
+
+Using macOS reference (`history.range.yesterday`, `history.range.week`, `history.range.month`, `history.metric.keys/clicks/move/scroll`, `keyBreakdown.empty`):
+
+`Strings.resx`:
+
+```xml
+  <data name="KeyHistory_WindowTitle" xml:space="preserve"><value>Key History</value></data>
+  <data name="KeyHistory_HeaderTitle" xml:space="preserve"><value>Key History</value></data>
+  <data name="History_Range_Yesterday" xml:space="preserve"><value>Yesterday</value></data>
+  <data name="History_Range_Last7Days" xml:space="preserve"><value>Last 7 days</value></data>
+  <data name="History_Range_Last30Days" xml:space="preserve"><value>Last 30 days</value></data>
+  <data name="KeyBreakdown_Empty" xml:space="preserve"><value>No key data yet</value></data>
+```
+
+`Strings.zh-Hans.resx`:
+
+```xml
+  <data name="KeyHistory_WindowTitle" xml:space="preserve"><value>历史按键统计</value></data>
+  <data name="KeyHistory_HeaderTitle" xml:space="preserve"><value>历史按键统计</value></data>
+  <data name="History_Range_Yesterday" xml:space="preserve"><value>昨天</value></data>
+  <data name="History_Range_Last7Days" xml:space="preserve"><value>过去7天</value></data>
+  <data name="History_Range_Last30Days" xml:space="preserve"><value>过去30天</value></data>
+  <data name="KeyBreakdown_Empty" xml:space="preserve"><value>暂无键位数据</value></data>
+```
+
+> If you find additional strings not covered here while inspecting (e.g., a chart legend), add new keys following the convention and update `Strings.cs` accordingly.
+
+- [ ] **Step 2: Add to `Strings.cs`**
+
+```csharp
+    public static string KeyHistory_WindowTitle => Get(nameof(KeyHistory_WindowTitle));
+    public static string KeyHistory_HeaderTitle => Get(nameof(KeyHistory_HeaderTitle));
+    public static string History_Range_Yesterday => Get(nameof(History_Range_Yesterday));
+    public static string History_Range_Last7Days => Get(nameof(History_Range_Last7Days));
+    public static string History_Range_Last30Days => Get(nameof(History_Range_Last30Days));
+    public static string KeyBreakdown_Empty => Get(nameof(KeyBreakdown_Empty));
+```
+
+- [ ] **Step 3: Migrate `KeyHistoryWindow.xaml`**
+
+Add `xmlns:p="clr-namespace:KeyStats.Properties"`. Replace each Chinese literal with the matching `{x:Static p:Strings.<Key>}`.
+
+- [ ] **Step 4: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+- [ ] **Step 5: Smoke test (Windows reviewer)**
+
+Open Key History window. Verify title, header, range chips, empty state (use a fresh user or skip if data exists).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/Views/KeyHistoryWindow.xaml
+git commit -m "feat(i18n): migrate KeyHistoryWindow strings"
+```
+
+---
+
+## Task 12: Migrate MouseCalibrationWindow
+
+This window is a wizard with multiple states (start / waiting / moving / success / failure). 15 XAML hits + 9 code-behind hits.
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/Views/MouseCalibrationWindow.xaml`
+- Modify: `KeyStats.Windows/KeyStats/Views/MouseCalibrationWindow.xaml.cs`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.zh-Hans.resx`
+- Modify: `KeyStats.Windows/KeyStats/Properties/Strings.cs`
+
+- [ ] **Step 1: Add keys to both `.resx` files**
+
+Reusing macOS keys (`settings.mouseDistanceCalibration.*`):
+
+`Strings.resx`:
+
+```xml
+  <data name="Calibration_WindowTitle" xml:space="preserve"><value>Mouse Distance Calibration</value></data>
+  <data name="Calibration_HeaderTitle" xml:space="preserve"><value>Mouse Distance Calibration</value></data>
+  <data name="Calibration_Instruction" xml:space="preserve"><value>Press any key to start recording, move 10 cm in a straight line, then press any key again to finish.</value></data>
+  <data name="Calibration_StartTitle" xml:space="preserve"><value>Mouse Distance Calibration</value></data>
+  <data name="Calibration_StartMessage" xml:space="preserve"><value>Prepare a 10 cm ruler. After clicking "Start", place the cursor at the start, press any key to begin recording, move 10 cm in a straight line, then press any key again to finish.</value></data>
+  <data name="Calibration_Start" xml:space="preserve"><value>Start</value></data>
+  <data name="Calibration_FinishTitle" xml:space="preserve"><value>Calibration in Progress</value></data>
+  <data name="Calibration_FinishMessage" xml:space="preserve"><value>Move the mouse in a straight line for 10 cm, then click "Finish".</value></data>
+  <data name="Calibration_Finish" xml:space="preserve"><value>Finish</value></data>
+  <data name="Calibration_SuccessTitle" xml:space="preserve"><value>Calibration Complete</value></data>
+  <data name="Calibration_SuccessMessageFormat" xml:space="preserve"><value>10 cm ≈ {0}, factor updated to {1}.</value></data>
+  <data name="Calibration_FailureTitle" xml:space="preserve"><value>Calibration Failed</value></data>
+  <data name="Calibration_FailureMessage" xml:space="preserve"><value>Movement was too short or not detected. Please try again.</value></data>
+  <data name="Calibration_StatusWaiting" xml:space="preserve"><value>Press any key to start recording...</value></data>
+  <data name="Calibration_StatusMovingFormat" xml:space="preserve"><value>Moved {0}</value></data>
+```
+
+`Strings.zh-Hans.resx`:
+
+```xml
+  <data name="Calibration_WindowTitle" xml:space="preserve"><value>鼠标距离校准</value></data>
+  <data name="Calibration_HeaderTitle" xml:space="preserve"><value>鼠标距离校准</value></data>
+  <data name="Calibration_Instruction" xml:space="preserve"><value>按任意键开始记录，沿直线移动 10cm，然后再按任意键结束。</value></data>
+  <data name="Calibration_StartTitle" xml:space="preserve"><value>鼠标距离校准</value></data>
+  <data name="Calibration_StartMessage" xml:space="preserve"><value>准备一把 10cm 标尺。点击"开始"后，将鼠标放在起点，按任意键开始记录；沿直线移动 10cm 后，再按任意键结束。</value></data>
+  <data name="Calibration_Start" xml:space="preserve"><value>开始</value></data>
+  <data name="Calibration_FinishTitle" xml:space="preserve"><value>正在校准</value></data>
+  <data name="Calibration_FinishMessage" xml:space="preserve"><value>请在 10cm 标尺上直线移动鼠标，完成后点击"完成"。</value></data>
+  <data name="Calibration_Finish" xml:space="preserve"><value>完成</value></data>
+  <data name="Calibration_SuccessTitle" xml:space="preserve"><value>校准完成</value></data>
+  <data name="Calibration_SuccessMessageFormat" xml:space="preserve"><value>10cm ≈ {0}，系数已更新为 {1}。</value></data>
+  <data name="Calibration_FailureTitle" xml:space="preserve"><value>校准失败</value></data>
+  <data name="Calibration_FailureMessage" xml:space="preserve"><value>移动距离过短或未检测到移动，请重试。</value></data>
+  <data name="Calibration_StatusWaiting" xml:space="preserve"><value>按任意键开始记录...</value></data>
+  <data name="Calibration_StatusMovingFormat" xml:space="preserve"><value>已移动 {0}</value></data>
+```
+
+- [ ] **Step 2: Add to `Strings.cs`**
+
+```csharp
+    public static string Calibration_WindowTitle => Get(nameof(Calibration_WindowTitle));
+    public static string Calibration_HeaderTitle => Get(nameof(Calibration_HeaderTitle));
+    public static string Calibration_Instruction => Get(nameof(Calibration_Instruction));
+    public static string Calibration_StartTitle => Get(nameof(Calibration_StartTitle));
+    public static string Calibration_StartMessage => Get(nameof(Calibration_StartMessage));
+    public static string Calibration_Start => Get(nameof(Calibration_Start));
+    public static string Calibration_FinishTitle => Get(nameof(Calibration_FinishTitle));
+    public static string Calibration_FinishMessage => Get(nameof(Calibration_FinishMessage));
+    public static string Calibration_Finish => Get(nameof(Calibration_Finish));
+    public static string Calibration_SuccessTitle => Get(nameof(Calibration_SuccessTitle));
+    public static string Calibration_SuccessMessageFormat => Get(nameof(Calibration_SuccessMessageFormat));
+    public static string Calibration_FailureTitle => Get(nameof(Calibration_FailureTitle));
+    public static string Calibration_FailureMessage => Get(nameof(Calibration_FailureMessage));
+    public static string Calibration_StatusWaiting => Get(nameof(Calibration_StatusWaiting));
+    public static string Calibration_StatusMovingFormat => Get(nameof(Calibration_StatusMovingFormat));
+```
+
+- [ ] **Step 3: Migrate `MouseCalibrationWindow.xaml`**
+
+Add `xmlns:p="clr-namespace:KeyStats.Properties"`. Replace each Chinese literal with the appropriate `{x:Static p:Strings.<Key>}`.
+
+For text bound to a status property (`{Binding StatusText}` etc.) the binding stays — you'll update the ViewModel side.
+
+For format strings shown statically in the wizard (e.g., the start message), use `{x:Static p:Strings.Calibration_StartMessage}` and bind the format result via code-behind if the message has placeholders.
+
+- [ ] **Step 4: Migrate `MouseCalibrationWindow.xaml.cs`**
+
+For each Chinese string in the code-behind:
+- `MessageBox.Show("...", "...", ...)` → use `Strings.*` keys.
+- `string.Format` calls → use `Strings.*Format` keys with `string.Format`.
+- Console logs → English.
+- The status text (e.g., `_statusText = "按任意键开始记录..."`) → `_statusText = KeyStats.Properties.Strings.Calibration_StatusWaiting`.
+- The "moved {x}" format → `string.Format(KeyStats.Properties.Strings.Calibration_StatusMovingFormat, x)`.
+
+- [ ] **Step 5: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+- [ ] **Step 6: Smoke test (Windows reviewer)**
+
+Open Settings → Distance Calibration → run a calibration end-to-end. Verify:
+- Window title, header, instruction text.
+- "Start" message and button.
+- Waiting state: "Press any key to start recording..."
+- Moving state: "Moved Xcm" / "已移动 Xcm" updates as you move.
+- Success message with placeholders rendering correctly.
+- Failure case (move <1 cm): correct failure message.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/Views/MouseCalibrationWindow.xaml KeyStats.Windows/KeyStats/Views/MouseCalibrationWindow.xaml.cs
+git commit -m "feat(i18n): migrate MouseCalibrationWindow strings"
+```
+
+---
+
+## Task 13: Migrate NotificationSettingsWindow + ImportModeDialog + ConfirmDialog
+
+These three are smaller and related. Group into one task.
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/Views/NotificationSettingsWindow.xaml`
+- Modify: `KeyStats.Windows/KeyStats/Views/ImportModeDialog.xaml`
+- Modify: `KeyStats.Windows/KeyStats/Views/ConfirmDialog.xaml`
+- Modify: `KeyStats.Windows/KeyStats/Views/ConfirmDialog.xaml.cs`
+- Modify: `KeyStats.Windows/KeyStats/Properties/*` (resx + cs)
+
+- [ ] **Step 1: Inspect each file and add keys**
+
+Each file is small enough to enumerate visually. Open each XAML and list every Chinese string.
+
+`Strings.resx` (English values):
+
+```xml
+  <!-- NotificationSettingsWindow -->
+  <data name="NotifSettings_WindowTitle" xml:space="preserve"><value>Notification Settings</value></data>
+  <data name="NotifSettings_HeaderTitle" xml:space="preserve"><value>Notification Settings</value></data>
+  <data name="NotifSettings_HeaderSubtitle" xml:space="preserve"><value>Configure notification thresholds for keys/clicks</value></data>
+  <data name="NotifSettings_Enable" xml:space="preserve"><value>Enable Stat Notifications</value></data>
+  <data name="NotifSettings_KeyThreshold" xml:space="preserve"><value>Key Press Threshold</value></data>
+  <data name="NotifSettings_ClickThreshold" xml:space="preserve"><value>Click Threshold</value></data>
+  <data name="NotifSettings_TimesUnit" xml:space="preserve"><value>times</value></data>
+
+  <!-- ImportModeDialog -->
+  <data name="ImportDialog_WindowTitle" xml:space="preserve"><value>Choose Import Mode</value></data>
+  <data name="ImportDialog_HeaderTitle" xml:space="preserve"><value>Choose Import Mode</value></data>
+  <data name="ImportDialog_HeaderSubtitle" xml:space="preserve"><value>Pick how to import: overwrite existing data or merge with it.</value></data>
+  <data name="ImportDialog_OverwriteTitle" xml:space="preserve"><value>Overwrite existing data</value></data>
+  <data name="ImportDialog_MergeTitle" xml:space="preserve"><value>Merge and accumulate</value></data>
+
+  <!-- ConfirmDialog -->
+  <data name="Confirm_DefaultTitle" xml:space="preserve"><value>Confirm</value></data>
+  <data name="Confirm_DefaultConfirm" xml:space="preserve"><value>Confirm</value></data>
+  <data name="Confirm_DefaultCancel" xml:space="preserve"><value>Cancel</value></data>
+```
+
+`Strings.zh-Hans.resx` (Chinese values):
+
+```xml
+  <data name="NotifSettings_WindowTitle" xml:space="preserve"><value>通知设置</value></data>
+  <data name="NotifSettings_HeaderTitle" xml:space="preserve"><value>通知设置</value></data>
+  <data name="NotifSettings_HeaderSubtitle" xml:space="preserve"><value>设置按键/点击阈值通知</value></data>
+  <data name="NotifSettings_Enable" xml:space="preserve"><value>开启统计通知</value></data>
+  <data name="NotifSettings_KeyThreshold" xml:space="preserve"><value>按键通知阈值</value></data>
+  <data name="NotifSettings_ClickThreshold" xml:space="preserve"><value>点击通知阈值</value></data>
+  <data name="NotifSettings_TimesUnit" xml:space="preserve"><value>次</value></data>
+
+  <data name="ImportDialog_WindowTitle" xml:space="preserve"><value>选择导入方式</value></data>
+  <data name="ImportDialog_HeaderTitle" xml:space="preserve"><value>选择导入方式</value></data>
+  <data name="ImportDialog_HeaderSubtitle" xml:space="preserve"><value>请选择导入方式：覆盖现有统计数据，或与现有数据合并累加。</value></data>
+  <data name="ImportDialog_OverwriteTitle" xml:space="preserve"><value>覆盖现有数据</value></data>
+  <data name="ImportDialog_MergeTitle" xml:space="preserve"><value>合并并累加</value></data>
+
+  <data name="Confirm_DefaultTitle" xml:space="preserve"><value>确认</value></data>
+  <data name="Confirm_DefaultConfirm" xml:space="preserve"><value>确认</value></data>
+  <data name="Confirm_DefaultCancel" xml:space="preserve"><value>取消</value></data>
+```
+
+> If you find strings not covered (e.g., placeholder hint text), add new keys.
+
+- [ ] **Step 2: Add to `Strings.cs`**
+
+```csharp
+    public static string NotifSettings_WindowTitle => Get(nameof(NotifSettings_WindowTitle));
+    public static string NotifSettings_HeaderTitle => Get(nameof(NotifSettings_HeaderTitle));
+    public static string NotifSettings_HeaderSubtitle => Get(nameof(NotifSettings_HeaderSubtitle));
+    public static string NotifSettings_Enable => Get(nameof(NotifSettings_Enable));
+    public static string NotifSettings_KeyThreshold => Get(nameof(NotifSettings_KeyThreshold));
+    public static string NotifSettings_ClickThreshold => Get(nameof(NotifSettings_ClickThreshold));
+    public static string NotifSettings_TimesUnit => Get(nameof(NotifSettings_TimesUnit));
+
+    public static string ImportDialog_WindowTitle => Get(nameof(ImportDialog_WindowTitle));
+    public static string ImportDialog_HeaderTitle => Get(nameof(ImportDialog_HeaderTitle));
+    public static string ImportDialog_HeaderSubtitle => Get(nameof(ImportDialog_HeaderSubtitle));
+    public static string ImportDialog_OverwriteTitle => Get(nameof(ImportDialog_OverwriteTitle));
+    public static string ImportDialog_MergeTitle => Get(nameof(ImportDialog_MergeTitle));
+
+    public static string Confirm_DefaultTitle => Get(nameof(Confirm_DefaultTitle));
+    public static string Confirm_DefaultConfirm => Get(nameof(Confirm_DefaultConfirm));
+    public static string Confirm_DefaultCancel => Get(nameof(Confirm_DefaultCancel));
+```
+
+- [ ] **Step 3: Migrate the three XAML files**
+
+In each file: add `xmlns:p="clr-namespace:KeyStats.Properties"`, replace every Chinese literal with the matching `{x:Static p:Strings.<Key>}`.
+
+- [ ] **Step 4: Migrate `ConfirmDialog.xaml.cs`**
+
+The Chinese strings in this file are likely default values for `Title` / `ConfirmText` / `CancelText` properties. Replace:
+
+```csharp
+public string Title { get; set; } = "确认";
+public string ConfirmText { get; set; } = "确认";
+public string CancelText { get; set; } = "取消";
+```
+
+with:
+
+```csharp
+public string Title { get; set; } = KeyStats.Properties.Strings.Confirm_DefaultTitle;
+public string ConfirmText { get; set; } = KeyStats.Properties.Strings.Confirm_DefaultConfirm;
+public string CancelText { get; set; } = KeyStats.Properties.Strings.Confirm_DefaultCancel;
+```
+
+> If `ConfirmDialog` exposes these as DependencyProperties with literal defaults in the metadata, change the metadata default to the `Strings.*` accessor instead.
+
+- [ ] **Step 5: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+- [ ] **Step 6: Smoke test (Windows reviewer)**
+
+- Open Settings → Notification Settings. Verify all labels.
+- Trigger an import (Settings → Import → choose a file). Verify import-mode dialog with two cards and subtitle.
+- Trigger any flow that uses ConfirmDialog (e.g., reset stats if exposed). Verify default title/buttons.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/Views/NotificationSettingsWindow.xaml KeyStats.Windows/KeyStats/Views/ImportModeDialog.xaml KeyStats.Windows/KeyStats/Views/ConfirmDialog.xaml KeyStats.Windows/KeyStats/Views/ConfirmDialog.xaml.cs
+git commit -m "feat(i18n): migrate NotificationSettings, ImportMode, Confirm dialogs"
+```
+
+---
+
+## Task 14: Migrate ViewModels
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/ViewModels/StatsPopupViewModel.cs`
+- Modify: `KeyStats.Windows/KeyStats/ViewModels/AppStatsViewModel.cs`
+- Modify: `KeyStats.Windows/KeyStats/ViewModels/KeyHistoryViewModel.cs`
+- Modify: `KeyStats.Windows/KeyStats/Properties/*`
+
+- [ ] **Step 1: Inspect each ViewModel and add keys**
+
+For each ViewModel, find the Chinese strings (mostly column headers, summary text, format strings, empty-state text). Common keys (assuming standard text from macOS):
+
+`Strings.resx`:
+
+```xml
+  <data name="AppStats_ColumnKeys" xml:space="preserve"><value>Keys</value></data>
+  <data name="AppStats_ColumnClicks" xml:space="preserve"><value>Clicks</value></data>
+  <data name="AppStats_ColumnScroll" xml:space="preserve"><value>Scroll</value></data>
+  <data name="AppStats_SortIndicator" xml:space="preserve"><value>↓</value></data>
+  <data name="AppStats_SummaryFormat" xml:space="preserve"><value>Total: {0} keys | {1} clicks | {2} scroll</value></data>
+  <data name="AppStats_Empty" xml:space="preserve"><value>No app data yet</value></data>
+  <data name="AppStats_Disabled" xml:space="preserve"><value>Per-app stats are disabled in Settings</value></data>
+  <data name="AppStats_UnknownApp" xml:space="preserve"><value>Unknown app</value></data>
+  <data name="History_TotalFormat" xml:space="preserve"><value>Total: {0}</value></data>
+  <data name="History_Empty" xml:space="preserve"><value>No data</value></data>
+```
+
+`Strings.zh-Hans.resx`:
+
+```xml
+  <data name="AppStats_ColumnKeys" xml:space="preserve"><value>键盘</value></data>
+  <data name="AppStats_ColumnClicks" xml:space="preserve"><value>点击</value></data>
+  <data name="AppStats_ColumnScroll" xml:space="preserve"><value>滚轮</value></data>
+  <data name="AppStats_SortIndicator" xml:space="preserve"><value>↓</value></data>
+  <data name="AppStats_SummaryFormat" xml:space="preserve"><value>总计: {0} 键盘 | {1} 点击 | {2} 滚动</value></data>
+  <data name="AppStats_Empty" xml:space="preserve"><value>暂无应用数据</value></data>
+  <data name="AppStats_Disabled" xml:space="preserve"><value>按应用统计已在设置中关闭</value></data>
+  <data name="AppStats_UnknownApp" xml:space="preserve"><value>未知应用</value></data>
+  <data name="History_TotalFormat" xml:space="preserve"><value>总计: {0}</value></data>
+  <data name="History_Empty" xml:space="preserve"><value>无数据</value></data>
+```
+
+> Add additional keys as needed when you find unforeseen strings.
+
+- [ ] **Step 2: Add to `Strings.cs`**
+
+```csharp
+    public static string AppStats_ColumnKeys => Get(nameof(AppStats_ColumnKeys));
+    public static string AppStats_ColumnClicks => Get(nameof(AppStats_ColumnClicks));
+    public static string AppStats_ColumnScroll => Get(nameof(AppStats_ColumnScroll));
+    public static string AppStats_SortIndicator => Get(nameof(AppStats_SortIndicator));
+    public static string AppStats_SummaryFormat => Get(nameof(AppStats_SummaryFormat));
+    public static string AppStats_Empty => Get(nameof(AppStats_Empty));
+    public static string AppStats_Disabled => Get(nameof(AppStats_Disabled));
+    public static string AppStats_UnknownApp => Get(nameof(AppStats_UnknownApp));
+    public static string History_TotalFormat => Get(nameof(History_TotalFormat));
+    public static string History_Empty => Get(nameof(History_Empty));
+```
+
+- [ ] **Step 3: Migrate each ViewModel**
+
+For each Chinese string in the file, replace with `KeyStats.Properties.Strings.<Key>` (or `string.Format(...)` for format strings).
+
+Example pattern in `AppStatsViewModel.cs`:
+
+```csharp
+// Before
+public string KeysHeader => "键盘 ↓";
+public string SummaryText => $"总计: {keys} 键盘 | {clicks} 点击 | {scroll} 滚动";
+public string EmptyText => "暂无应用数据";
+
+// After
+public string KeysHeader => $"{KeyStats.Properties.Strings.AppStats_ColumnKeys} {KeyStats.Properties.Strings.AppStats_SortIndicator}";
+public string SummaryText => string.Format(KeyStats.Properties.Strings.AppStats_SummaryFormat, keys, clicks, scroll);
+public string EmptyText => KeyStats.Properties.Strings.AppStats_Empty;
+```
+
+> Make sure to fire `OnPropertyChanged` for these computed properties if their values are cached or if the ViewModel was previously assigning literal strings to backing fields. If they're computed expression-bodied properties (`=>`), a single `OnPropertyChanged(nameof(...))` call is enough when sort state changes — same as before.
+
+In `StatsPopupViewModel.cs`, the 2 hits are likely status/format strings — translate similarly.
+
+In `KeyHistoryViewModel.cs`, the 2 hits are likely range labels — use `History_Range_*` keys (already added in Task 11).
+
+- [ ] **Step 4: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+- [ ] **Step 5: Smoke test (Windows reviewer)**
+
+- Open StatsPopup → confirm any ViewModel-driven labels (history summary at the bottom).
+- Open AppStats window → verify column headers (Keys/Clicks/Scroll) and summary line and empty state.
+- Open KeyHistory → verify range labels.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/ViewModels/
+git commit -m "feat(i18n): migrate ViewModel strings"
+```
+
+---
+
+## Task 15: Migrate custom controls
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/Views/Controls/KeyBreakdownControl.xaml`
+- Modify: `KeyStats.Windows/KeyStats/Views/Controls/StatsChartControl.xaml.cs`
+- Modify: `KeyStats.Windows/KeyStats/Views/Controls/KeyDistributionPieChartControl.xaml.cs`
+
+- [ ] **Step 1: Inspect each control**
+
+`KeyBreakdownControl.xaml` — 1 hit, the empty state. Use the existing `KeyBreakdown_Empty` key (added in Task 11).
+
+`StatsChartControl.xaml.cs` — 15 hits. These are mostly chart legend labels and tooltip format strings. Likely overlap with metric/range keys we already have:
+
+`Strings.resx` (only new keys not already added):
+
+```xml
+  <data name="Chart_Tooltip_DateFormat" xml:space="preserve"><value>{0:yyyy-MM-dd}</value></data>
+  <data name="Chart_Tooltip_ValueFormat" xml:space="preserve"><value>{0}: {1}</value></data>
+```
+
+`Strings.zh-Hans.resx`:
+
+```xml
+  <data name="Chart_Tooltip_DateFormat" xml:space="preserve"><value>{0:yyyy年M月d日}</value></data>
+  <data name="Chart_Tooltip_ValueFormat" xml:space="preserve"><value>{0}：{1}</value></data>
+```
+
+> Inspect the actual file: if it uses different formats or includes day-of-week ("星期一" etc.), add those as `Chart_Tooltip_*Format` keys with locale-appropriate templates.
+
+`KeyDistributionPieChartControl.xaml.cs` — 4 hits, likely legend labels. If standard "其他" (Other), add:
+
+`Strings.resx`:
+```xml
+  <data name="PieChart_Other" xml:space="preserve"><value>Other</value></data>
+```
+
+`Strings.zh-Hans.resx`:
+```xml
+  <data name="PieChart_Other" xml:space="preserve"><value>其他</value></data>
+```
+
+- [ ] **Step 2: Add to `Strings.cs`**
+
+```csharp
+    public static string Chart_Tooltip_DateFormat => Get(nameof(Chart_Tooltip_DateFormat));
+    public static string Chart_Tooltip_ValueFormat => Get(nameof(Chart_Tooltip_ValueFormat));
+    public static string PieChart_Other => Get(nameof(PieChart_Other));
+```
+
+- [ ] **Step 3: Migrate the controls**
+
+For `KeyBreakdownControl.xaml`: replace the empty-state text with `{x:Static p:Strings.KeyBreakdown_Empty}` (add `xmlns:p="..."`).
+
+For each `.xaml.cs` file: replace each Chinese literal with `KeyStats.Properties.Strings.<Key>` or `string.Format(...)` as appropriate.
+
+- [ ] **Step 4: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+- [ ] **Step 5: Smoke test (Windows reviewer)**
+
+- StatsPopup → Key Distribution section → verify empty state text.
+- StatsPopup → History chart → hover for tooltip; verify date and value format.
+- (KeyDistributionPieChartControl is used somewhere; find it in usage and verify the "Other" segment label.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/Views/Controls/
+git commit -m "feat(i18n): migrate custom controls strings"
+```
+
+---
+
+## Task 16: Migrate Services
+
+`StatsManager.cs` (11 hits), `NotificationService.cs` (3 hits), `InputMonitorService.cs` (6 hits).
+
+Strategy:
+- **Console.WriteLine logs** → translate to English (developer-facing; not localized).
+- **Exception messages thrown to be displayed** → use `Strings.*Format` keys (translate).
+- **Toast text** in NotificationService → use `Strings.*` keys (translate).
+
+**Files:**
+- Modify: `KeyStats.Windows/KeyStats/Services/StatsManager.cs`
+- Modify: `KeyStats.Windows/KeyStats/Services/NotificationService.cs`
+- Modify: `KeyStats.Windows/KeyStats/Services/InputMonitorService.cs`
+- Modify: `KeyStats.Windows/KeyStats/Properties/*`
+
+- [ ] **Step 1: Inspect each service**
+
+Open each file. Categorize each Chinese string:
+- Console.WriteLine(...) / Debug.WriteLine(...) → English literal.
+- `throw new Exception("...")` whose `.Message` may be shown to users → translated key.
+- ToastContentBuilder().AddText("...") → translated key.
+
+Likely keys for `NotificationService.cs`:
+
+`Strings.resx`:
+
+```xml
+  <data name="Notif_ThresholdTitle" xml:space="preserve"><value>KeyStats Reminder</value></data>
+  <data name="Notif_KeyThresholdReachedFormat" xml:space="preserve"><value>Today's key presses reached {0:N0}.</value></data>
+  <data name="Notif_ClickThresholdReachedFormat" xml:space="preserve"><value>Today's clicks reached {0:N0}.</value></data>
+```
+
+`Strings.zh-Hans.resx`:
+
+```xml
+  <data name="Notif_ThresholdTitle" xml:space="preserve"><value>统计提醒</value></data>
+  <data name="Notif_KeyThresholdReachedFormat" xml:space="preserve"><value>今日按键数已达到 {0:N0} 次</value></data>
+  <data name="Notif_ClickThresholdReachedFormat" xml:space="preserve"><value>今日点击数已达到 {0:N0} 次</value></data>
+```
+
+Likely keys for `StatsManager.cs` exception messages:
+
+`Strings.resx`:
+
+```xml
+  <data name="Error_ImportInvalidFormat" xml:space="preserve"><value>Data format is invalid.</value></data>
+  <data name="Error_ImportUnsupportedVersion" xml:space="preserve"><value>Unsupported export version.</value></data>
+  <data name="Error_ImportEmpty" xml:space="preserve"><value>Selected file is empty.</value></data>
+```
+
+`Strings.zh-Hans.resx`:
+
+```xml
+  <data name="Error_ImportInvalidFormat" xml:space="preserve"><value>数据格式无效。</value></data>
+  <data name="Error_ImportUnsupportedVersion" xml:space="preserve"><value>不支持的导出版本。</value></data>
+  <data name="Error_ImportEmpty" xml:space="preserve"><value>所选文件为空。</value></data>
+```
+
+- [ ] **Step 2: Add to `Strings.cs`**
+
+```csharp
+    public static string Notif_ThresholdTitle => Get(nameof(Notif_ThresholdTitle));
+    public static string Notif_KeyThresholdReachedFormat => Get(nameof(Notif_KeyThresholdReachedFormat));
+    public static string Notif_ClickThresholdReachedFormat => Get(nameof(Notif_ClickThresholdReachedFormat));
+    public static string Error_ImportInvalidFormat => Get(nameof(Error_ImportInvalidFormat));
+    public static string Error_ImportUnsupportedVersion => Get(nameof(Error_ImportUnsupportedVersion));
+    public static string Error_ImportEmpty => Get(nameof(Error_ImportEmpty));
+```
+
+- [ ] **Step 3: Migrate `NotificationService.cs`**
+
+```csharp
+// Before
+new ToastContentBuilder()
+    .AddText("KeyStats")
+    .AddText($"Today's key presses reached {count:N0}!")
+    .Show();
+
+// After
+new ToastContentBuilder()
+    .AddText(KeyStats.Properties.Strings.Notif_ThresholdTitle)
+    .AddText(string.Format(KeyStats.Properties.Strings.Notif_KeyThresholdReachedFormat, count))
+    .Show();
+```
+
+(Adapt for the click variant similarly.)
+
+- [ ] **Step 4: Migrate `StatsManager.cs`**
+
+For each Chinese exception message, replace with the matching key. For each Chinese Console.WriteLine, rewrite the literal in English. Example:
+
+```csharp
+// Before
+throw new InvalidDataException("数据格式无效。");
+Console.WriteLine("加载统计数据失败...");
+
+// After
+throw new InvalidDataException(KeyStats.Properties.Strings.Error_ImportInvalidFormat);
+Console.WriteLine("Failed to load stats data...");
+```
+
+- [ ] **Step 5: Migrate `InputMonitorService.cs`**
+
+The 6 hits are likely all Console.WriteLine debug output. Convert each to English. No new resource keys needed unless any string is user-visible (unlikely in this file).
+
+- [ ] **Step 6: Build**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Debug
+```
+
+- [ ] **Step 7: Smoke test (Windows reviewer)**
+
+- Trigger a key-threshold notification (set threshold low enough; type until it fires). Verify toast title/body in current language.
+- Trigger a click-threshold notification.
+- Try importing a malformed JSON file. Verify the error toast/message uses the translated text.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add KeyStats.Windows/KeyStats/Properties/ KeyStats.Windows/KeyStats/Services/
+git commit -m "feat(i18n): migrate Service strings + convert Console logs to English"
+```
+
+---
+
+## Task 17: Final residual scan + verification matrix
+
+After all migration tasks, run a final scan to ensure no Chinese leaks into source files (excluding intentional locations).
+
+**Files:**
+- No source modifications expected unless the scan finds stragglers.
+
+- [ ] **Step 1: Run residual scan**
+
+```bash
+cd KeyStats.Windows
+grep -rnE '[一-鿿]' KeyStats/ \
+  --include='*.cs' --include='*.xaml' \
+  | grep -v '/Properties/Strings.zh-Hans.resx' \
+  | grep -v 'KeyNameMapper' \
+  | grep -v '// '
+```
+
+Expected: empty output.
+
+If output is non-empty:
+- For each line, decide whether the Chinese is intentional (a comment, a `KeyNameMapper` physical key label) or a missed string.
+- Missed strings: add the appropriate key to both `.resx` files, add to `Strings.cs`, replace in source. Build. Repeat the scan.
+
+- [ ] **Step 2: Run resx key consistency check**
+
+```bash
+cd KeyStats.Windows/KeyStats/Properties
+
+# Extract all keys from each resx
+grep -oE '<data name="[^"]+"' Strings.resx | sort -u > /tmp/keys-en.txt
+grep -oE '<data name="[^"]+"' Strings.zh-Hans.resx | sort -u > /tmp/keys-zh.txt
+
+# Show diffs
+diff /tmp/keys-en.txt /tmp/keys-zh.txt
+```
+
+Expected: empty output (key sets match exactly).
+
+If keys differ: add the missing key to whichever file is short. (Missing in zh-Hans = harmless fallback to English; missing in en = a real bug since en is also fallback for `de-DE` etc.)
+
+- [ ] **Step 3: Build the release configuration to confirm packaging**
+
+```
+dotnet build KeyStats/KeyStats.csproj -c Release
+```
+
+Inspect `KeyStats.Windows/KeyStats/bin/Release/net48/`:
+- `KeyStats.exe` should exist.
+- `zh-Hans/KeyStats.resources.dll` (satellite assembly) should exist.
+
+If satellite missing: fix the `KeyStats.csproj` `<EmbeddedResource>` block from Task 1, Step 4.
+
+- [ ] **Step 4: Run the full distribution package**
+
+```
+powershell -ExecutionPolicy Bypass -File ./build.ps1 -Configuration Release
+```
+
+(This is the existing `build.ps1` script.) Confirm `dist/KeyStats-Windows-<version>.zip` is produced and includes the satellite folder.
+
+- [ ] **Step 5: Run the verification matrix manually (Windows reviewer)**
+
+For each row, launch the app under the conditions and confirm the expected outcome.
+
+**Startup language detection (clear `settings.json` between rows or set `languagePreference: "system"`):**
+
+| System UI language | Expected app UI |
+|---|---|
+| `zh-CN` | 中文 |
+| `zh-Hans-CN` | 中文 |
+| `zh` | 中文 |
+| `zh-TW` | English |
+| `zh-HK` | English |
+| `en-US` | English |
+| `ja-JP` | English |
+| `de-DE` | English |
+
+Use PowerShell to test variations: `Set-WinUILanguageOverride zh-TW` then restart the app.
+
+**Manual override:**
+
+| Scenario | Expected |
+|---|---|
+| Fresh install (no `settings.json`) | Auto-detected language |
+| `languagePreference: "system"` | Auto-detected language |
+| `languagePreference: "zh-Hans"` | 中文 (even on English system) |
+| `languagePreference: "en"` | English (even on Chinese system) |
+| `languagePreference: "fr"` (typo) | Fallback to auto-detect, no crash |
+| Old `settings.json` without `languagePreference` field | Default to `"system"`, no crash |
+
+**Switch flow:**
+
+1. Open Settings → change Language → restart prompt → OK → app exits → relaunches → new language applied. Setting is persisted.
+2. Same as above, but click Cancel → ComboBox reverts to old value → settings unchanged → no restart.
+
+**UI completeness — visit each window in BOTH languages:**
+
+- [ ] StatsPopup (left-click tray icon)
+- [ ] Settings (right-click tray → Settings)
+- [ ] NotificationSettings (Settings → Notifications)
+- [ ] MouseCalibration (Settings → Distance Calibration → run end-to-end)
+- [ ] AppStats
+- [ ] KeyboardHeatmap
+- [ ] KeyHistory
+- [ ] ImportModeDialog (trigger via Settings → Import)
+- [ ] ConfirmDialog (find any flow that uses it)
+
+For each: title, every button, every label, ToolTips, format strings, empty states.
+
+**Edge cases:**
+
+- [ ] Long English strings don't break SettingsWindow card layout.
+- [ ] Numbers still display per system locale (e.g., `1,234.56` on en-US, `1,234.56` on zh-CN since Chinese also uses comma thousands).
+- [ ] Toasts trigger correctly in both languages.
+
+- [ ] **Step 6: Commit (only if Step 1 found issues to fix)**
+
+If the residual scan found nothing and no fixes were needed, no commit is necessary at this task — just sign off the verification matrix in the PR description.
+
+If fixes were needed:
+
+```bash
+git add KeyStats.Windows/KeyStats/
+git commit -m "fix(i18n): catch residual hardcoded strings"
+```
+
+---
+
+## Self-review checklist
+
+Spec coverage:
+- [x] Goal 1: auto-detect from system → Task 2 (LocalizationManager.DetectFromSystem)
+- [x] Goal 2: Settings dropdown override → Task 6
+- [x] Goal 3: restart on switch → Task 6 (RestartApp + mutex retry in Task 4)
+- [x] Goal 4: reuse macOS translations → embedded throughout (each task references macOS source where applicable)
+- [x] Non-goal: no live switch → restart-only flow only
+- [x] Non-goal: don't translate KeyNameMapper / JSON keys / unit suffixes → spec-aligned (no changes to those files)
+- [x] `.resx` + strongly-typed accessor → Tasks 1-2
+- [x] `LocalizationManager` with `Resolve` and `DetectFromSystem` → Task 2
+- [x] `AppSettings.LanguagePreference` string field → Task 3
+- [x] App.xaml.cs startup wiring + mutex retry + English fallback → Task 4
+- [x] Tray menu, toasts, dialog titles → Task 5
+- [x] Settings Language card + restart flow → Task 6
+- [x] All 9 windows migrated → Tasks 7-13
+- [x] ViewModels + custom controls → Tasks 14-15
+- [x] Services with English Console logs → Task 16
+- [x] Final residual scan + verification matrix → Task 17
+
+No placeholder strings or "TBD" entries — every code/XML block is concrete.
+
+Type / API consistency:
+- `LocalizationManager.ApplyAtStartup(string)` signature is the same in Task 2 (definition) and Task 4 (call site).
+- `AppSettings.LanguagePreference` is `string` with default `"system"` everywhere.
+- `Strings.<Key>` accessors are added incrementally; each task adds keys to both `.resx` files AND `Strings.cs` together — no risk of compile-time mismatch.
+- ComboBox `Tag` values (`"system"` / `"zh-Hans"` / `"en"`) match `LanguagePreference` accepted values exactly.

--- a/docs/superpowers/specs/2026-04-29-windows-i18n-design.md
+++ b/docs/superpowers/specs/2026-04-29-windows-i18n-design.md
@@ -1,0 +1,624 @@
+# Windows 版 KeyStats 中英文 i18n 设计
+
+**日期**：2026-04-29
+**分支**：`feat/win-i18n`
+**状态**：已与用户对齐，待写实施计划
+
+## 背景
+
+KeyStats Windows 版（`KeyStats.Windows/`，WPF + .NET Framework 4.8）当前 UI 仅有简体中文，硬编码散落在 25 个 `*.cs` / `*.xaml` 文件中、约 358 处。macOS 版已有完整双语（`KeyStats/{en,zh-Hans}.lproj/Localizable.strings`，约 231 个 key）。
+
+本次目标：让 Windows 版同时支持简体中文和英文，启动时跟随系统语言，并在 Settings 里提供手动覆盖。
+
+## 目标
+
+- 启动时根据系统 UI 语言决定显示中文或英文：
+  - 简体中文（`zh-CN` / `zh-Hans*` / `zh`）→ 中文
+  - 其它一切（含繁体 `zh-TW`/`zh-HK`、英文、日文等）→ 英文
+- 在「设置」里提供 Language 下拉（System / 中文 / English），用户可手动覆盖系统判定
+- 切换语言通过 **重启应用** 生效（用户确认后自动重启）
+- 复用 macOS 版已有的翻译，避免术语不一致和重复翻译工作
+
+## 非目标
+
+- 不支持运行时实时切换语言（设计上选了重启方案）
+- 不支持繁体中文（需要时再单独立项）
+- 不本地化数字/日期格式（仅 UI 文案；`CurrentCulture` 保持系统默认）
+- 不本地化 `KeyNameMapper` 输出的物理键名（`Backspace`/`Tab`/`Ctrl+Shift+A`，这是按键标签而非 UI 文案）
+- 不本地化 PostHog 事件名/属性、Console 调试日志、JSON 持久化字段名、应用名 `KeyStats`、单位后缀 `m`/`km`/`px`/`k`、ISO 日期格式
+
+## 技术方案：`.resx` + 强类型 `Strings` 静态类
+
+### 选型理由
+
+候选了两个方案：
+
+| 方案 | 优点 | 缺点 |
+|---|---|---|
+| **`.resx` + 强类型 `Strings.Designer.cs`**（采纳） | .NET 原生零依赖；编译期 key 校验；VS 内建 `.resx` 编辑器；与"重启切换"模型完美契合 | XML merge conflict 略丑（key 数 ~200 可控） |
+| JSON + 自定义 `L10n.T("key")` 辅助类 | key 命名风格自由；JSON 比 XML 友好 | 完全手写（MarkupExtension、loader、fallback）；失去编译期检查；重复造轮子 |
+
+选 `.resx`：编译期 key 校验是 200+ key 工程的硬刚需；不需要自定义 MarkupExtension；以后想加运行时切换也能升级到 DynamicResource + 自定义 provider，不会卡死。
+
+## 架构
+
+### 文件布局
+
+```
+KeyStats.Windows/KeyStats/
+├── Properties/
+│   ├── Strings.resx              # 中性（英文，默认 + fallback）
+│   ├── Strings.zh-Hans.resx      # 简体中文
+│   └── Strings.Designer.cs       # 自动生成，入库
+├── Helpers/
+│   └── LocalizationManager.cs    # 新增：语言检测 + 应用 + 切换
+├── Models/
+│   └── AppSettings.cs            # 新增字段 LanguagePreference
+└── Views/
+    └── SettingsWindow.xaml       # 新增 Language 卡片（放在最后）
+```
+
+### 三个核心组件
+
+#### 1. `Strings.resx`（资源）
+
+- `Strings.resx` = 英文（中性 = 默认 = fallback）
+- `Strings.zh-Hans.resx` = 简体中文
+- 命名约定：`PascalCase + 类别前缀_`
+  - `Settings_Title`、`Settings_DataImportExport`、`Settings_Language`
+  - `Tray_OpenMainWindow`、`Tray_Quit`
+  - `Notification_KeyThresholdReachedFormat`
+  - `Error_AppAlreadyRunning`、`Error_StartupFailedFormat`
+  - `Common_Ok`、`Common_Cancel`、`Common_Close`、`Common_Retry`
+  - `Toast_ExportSuccess_Title`、`Toast_ExportSuccess_BodyFormat`
+- 占位符用 `{0}` / `{1}`（C# `string.Format` 风格），不用 macOS 的 `%@` / `%1$@`
+- `.resx` 和自动生成的 `Strings.Designer.cs` 都入库到 git
+- key 数量预估 ~200，最终以盘点结果为准
+
+#### 2. `LocalizationManager`（Helper 单例）
+
+```csharp
+public enum LanguagePreference { System, ZhHans, English }
+
+public static class LocalizationManager
+{
+    // 启动时调用，必须在任何 UI 加载前
+    public static void ApplyAtStartup(string languagePreference)
+    {
+        var culture = languagePreference switch
+        {
+            "zh-Hans" => new CultureInfo("zh-Hans"),
+            "en"      => new CultureInfo("en"),
+            _         => DetectFromSystem(),  // "system" 或任何未知值都走自动检测
+        };
+
+        Thread.CurrentThread.CurrentUICulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        // CurrentCulture（数字/日期格式）保持系统默认，不动
+    }
+
+    private static CultureInfo DetectFromSystem()
+    {
+        var sys = CultureInfo.CurrentUICulture;
+        if (sys.Name.StartsWith("zh-Hans", StringComparison.OrdinalIgnoreCase) ||
+            sys.Name.Equals("zh-CN", StringComparison.OrdinalIgnoreCase) ||
+            sys.Name.Equals("zh", StringComparison.OrdinalIgnoreCase))
+        {
+            return new CultureInfo("zh-Hans");
+        }
+        return new CultureInfo("en");
+    }
+}
+```
+
+关键点：
+- 只设 `CurrentUICulture`（管资源查找），不动 `CurrentCulture`
+- `zh-Hans` 是中性 culture，`ResourceManager` 会找到 `Strings.zh-Hans.resx`
+- 解析失败 / 卫星 dll 缺失 → `ResourceManager` 自动回退到中性 `Strings.resx`（英文），不 crash
+- `CultureInfo.DefaultThreadCurrentUICulture` 覆盖后续创建的所有线程
+
+#### 3. `AppSettings.LanguagePreference`（持久化）
+
+```csharp
+[JsonPropertyName("languagePreference")]
+public string LanguagePreference { get; set; } = "system";  // "system" | "zh-Hans" | "en"
+```
+
+字符串而非 enum：JSON 兼容老版本（老用户没这个字段，反序列化 default `"system"` = 自动检测）；写错值（如 `"fr"`）也安全 fallback 到自动检测。
+
+### 数据流
+
+```
+App 启动
+  → 加载 settings.json（StatsManager.Instance.Settings）
+  → LocalizationManager.ApplyAtStartup(settings.LanguagePreference)
+        ├─ "system" → DetectFromSystem() → en or zh-Hans
+        ├─ "zh-Hans" → new CultureInfo("zh-Hans")
+        └─ "en"     → new CultureInfo("en")
+  → 设置 Thread.CurrentUICulture + DefaultThreadCurrentUICulture
+  → ThemeManager.Initialize() ...
+  → 后续所有 Strings.* 访问自动用这个 culture
+  → XAML 加载时 x:Static 静态读取，UI 显示对应语言
+```
+
+切换流程：
+
+```
+用户在 Settings 下拉里改 Language
+  → SelectionChanged 事件
+  → 弹重启确认对话框
+  ├─ 取消 → ComboBox 选回旧值，settings.json 不变
+  └─ 确认 → 写 settings.LanguagePreference + SaveSettings()
+         → Process.Start(exePath)（新进程会 mutex 重试 1-2 次）
+         → Application.Current.Shutdown()
+         → 旧进程 OnExit 跑完（flush stats + analytics + theme cleanup）
+         → 新进程启动，按新语言加载 UI
+```
+
+## 启动流程改造
+
+### 改动位置：`App.xaml.cs::OnStartup`
+
+新流程在异常处理器之后、单实例 mutex 检查之前插入：
+
+```csharp
+protected override void OnStartup(StartupEventArgs e)
+{
+    base.OnStartup(e);
+    // ... 异常处理器 ...
+
+    // [新增] 提前加载 settings 拿到语言偏好
+    var settings = StatsManager.Instance.Settings;
+
+    // [新增] 应用语言（必须在任何 UI 加载之前）
+    LocalizationManager.ApplyAtStartup(settings.LanguagePreference);
+
+    // 单实例 mutex
+    var mutex = new Mutex(true, "KeyStats_SingleInstance", out bool createdNew);
+    if (!createdNew)
+    {
+        // mutex 失败时用纯英文兜底（语言已加载但保持简单一致）
+        MessageBox.Show("KeyStats is already running.", "KeyStats",
+                        MessageBoxButton.OK, MessageBoxImage.Information);
+        Shutdown();
+        return;
+    }
+
+    ThemeManager.Instance.Initialize();
+    // ... 后续不变 ...
+}
+```
+
+注意：mutex 失败提示用纯英文（不走 `Strings.*`），因为这是兜底场景，简单可靠优先。
+
+## 迁移模式
+
+### 类别 1：XAML 静态文本
+
+XAML 顶部加 namespace：
+
+```xml
+xmlns:p="clr-namespace:KeyStats.Properties"
+```
+
+替换：
+
+```xml
+<!-- 前 -->
+<Window Title="设置 - KeyStats" />
+<TextBlock Text="数据导入 / 导出" />
+<Button Content="导入" />
+<TextBlock ToolTip="打开 GitHub 仓库" />
+
+<!-- 后 -->
+<Window Title="{x:Static p:Strings.Settings_WindowTitle}" />
+<TextBlock Text="{x:Static p:Strings.Settings_DataImportExport}" />
+<Button Content="{x:Static p:Strings.Common_Import}" />
+<TextBlock ToolTip="{x:Static p:Strings.Settings_GitHubTooltip}" />
+```
+
+注意：`x:Static` 是编译期解析；新增 key 后必须重新构建一次让 Designer.cs 更新，XAML 才能识别。
+
+### 类别 2：C# 错误提示和异常消息
+
+```csharp
+// 前
+MessageBox.Show("启动错误: " + ex.Message, "按键统计错误", ...);
+
+// 后
+MessageBox.Show(string.Format(Strings.Error_StartupFailedFormat, ex.Message),
+                Strings.App_Name, ...);
+```
+
+带占位符的 key 用 `*Format` 后缀：
+
+```
+Error_StartupFailedFormat = "Startup error: {0}"
+Notification_KeysReachedFormat = "Today's key presses reached {0:N0}!"
+```
+
+### 类别 3：托盘菜单（`App.xaml.cs::CreateContextMenu`）
+
+```csharp
+// 前
+var openMainWindowItem = new MenuItem { Header = "打开主界面" };
+
+// 后
+var openMainWindowItem = new MenuItem { Header = Strings.Tray_OpenMainWindow };
+```
+
+5 个菜单项全部走 `Strings.Tray_*`：`OpenMainWindow`、`Settings`、`StartAtLogin`、`KeyHistory`、`Quit`。
+
+### 类别 4：Toast 通知
+
+```csharp
+// 前
+new ToastContentBuilder()
+    .AddText("导出成功")
+    .AddText($"数据已保存到 {Path.GetFileName(dialog.FileName)}")
+    .Show();
+
+// 后
+new ToastContentBuilder()
+    .AddText(Strings.Toast_ExportSuccess_Title)
+    .AddText(string.Format(Strings.Toast_ExportSuccess_BodyFormat, Path.GetFileName(dialog.FileName)))
+    .Show();
+```
+
+### 类别 5：ViewModel 格式化字符串
+
+业务文案翻译，物理单位保持英文：
+
+```csharp
+// 前
+public string EmptyStateText => "暂无按键记录";
+public string FormattedMouseDistance =>
+    MouseDistance >= 1000 ? $"{MouseDistance / 1000:N2} km" : $"{MouseDistance:N2} m";
+
+// 后
+public string EmptyStateText => Strings.KeyBreakdown_EmptyState;
+// 距离格式化保持原状（"m" / "km" 是国际单位，不翻译）
+```
+
+### 类别 6：Service 层
+
+- 用户可见的异常 message（最终冒泡到 MessageBox）→ 翻译
+- `Console.WriteLine` 调试日志 → **不翻译**，借此机会把残留的中文日志统一改成英文（可选）
+
+```csharp
+// 异常 message 翻译
+throw new InvalidOperationException(Strings.Error_ImportInvalidFormat);
+
+// Console 日志保持英文
+Console.WriteLine("KeyStats starting...");
+Console.WriteLine($"Failed to capture event {eventName}: {ex}");
+```
+
+### 类别 7：Window.Title
+
+每个窗口的 `Title` 一律走 `{x:Static p:Strings.*_WindowTitle}`，9 个窗口都改：`SettingsWindow` / `StatsPopupWindow` / `AppStatsWindow` / `KeyboardHeatmapWindow` / `KeyHistoryWindow` / `MouseCalibrationWindow` / `NotificationSettingsWindow` / `ConfirmDialog` / `ImportModeDialog`。
+
+## Settings UI 改动
+
+### XAML 新增「Language」卡片（放在最后）
+
+放在「数据导入/导出」、「通知设置」、「距离校准」之后，沿用现有 `CardBorder` + `GhostButton` 风格：
+
+```xml
+<Border Style="{DynamicResource CardBorder}" Margin="0,0,0,4" Padding="14,12">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+        <StackPanel Grid.Column="0">
+            <TextBlock Text="{x:Static p:Strings.Settings_Language}"
+                       FontSize="13" FontWeight="SemiBold"
+                       Foreground="{DynamicResource TextPrimaryBrush}"/>
+            <TextBlock Text="{x:Static p:Strings.Settings_LanguageDescription}"
+                       FontSize="12"
+                       Foreground="{DynamicResource TextSecondaryBrush}" Margin="0,4,0,0"/>
+        </StackPanel>
+        <ComboBox Grid.Column="1"
+                  x:Name="LanguageComboBox"
+                  MinWidth="140"
+                  SelectionChanged="LanguageComboBox_SelectionChanged">
+            <ComboBoxItem Content="{x:Static p:Strings.Settings_Language_System}" Tag="system"/>
+            <ComboBoxItem Content="中文" Tag="zh-Hans"/>
+            <ComboBoxItem Content="English" Tag="en"/>
+        </ComboBox>
+    </Grid>
+</Border>
+```
+
+注意：`中文` 和 `English` 自指（不管当前 UI 是什么语言，看到 "中文" 就知道是中文，看到 "English" 就知道是英文），不走 `Strings.*`。只有 "System / 跟随系统" 这一项随当前 UI 翻译。
+
+### Code-behind 行为（`SettingsWindow.xaml.cs`）
+
+```csharp
+private bool _isInitializing = true;
+
+private void OnLoaded(...)
+{
+    var current = StatsManager.Instance.Settings.LanguagePreference;
+    LanguageComboBox.SelectedItem = LanguageComboBox.Items
+        .Cast<ComboBoxItem>()
+        .FirstOrDefault(i => (string)i.Tag == current)
+        ?? LanguageComboBox.Items[0];
+    _isInitializing = false;
+}
+
+private void LanguageComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+{
+    if (_isInitializing) return;
+
+    var newPref = (string)((ComboBoxItem)LanguageComboBox.SelectedItem).Tag;
+    var oldPref = StatsManager.Instance.Settings.LanguagePreference;
+    if (newPref == oldPref) return;
+
+    var result = MessageBox.Show(
+        Strings.Language_RestartPromptMessage,
+        Strings.Language_RestartPromptTitle,
+        MessageBoxButton.OKCancel,
+        MessageBoxImage.Information);
+
+    if (result == MessageBoxResult.OK)
+    {
+        StatsManager.Instance.Settings.LanguagePreference = newPref;
+        StatsManager.Instance.SaveSettings();
+        RestartApp();
+    }
+    else
+    {
+        // 用户取消 → ComboBox 选回旧值
+        _isInitializing = true;
+        LanguageComboBox.SelectedItem = LanguageComboBox.Items
+            .Cast<ComboBoxItem>()
+            .FirstOrDefault(i => (string)i.Tag == oldPref);
+        _isInitializing = false;
+    }
+}
+
+private static void RestartApp()
+{
+    var exePath = Process.GetCurrentProcess().MainModule?.FileName;
+    if (!string.IsNullOrEmpty(exePath))
+    {
+        Process.Start(exePath);
+    }
+    Application.Current.Shutdown();
+}
+```
+
+### 重启时 mutex 冲突处理
+
+旧进程 `Shutdown()` 后会跑 `OnExit`（flush + cleanup），mutex 在 `OnExit` 末尾才释放。新进程立即启动可能 mutex 还在。
+
+方案：**新进程启动时 mutex 重试 1-2 次**（500ms 间隔）。改 `OnStartup` 的 mutex 检查：
+
+```csharp
+Mutex? mutex = null;
+bool createdNew = false;
+for (int attempt = 0; attempt < 3; attempt++)
+{
+    mutex = new Mutex(true, "KeyStats_SingleInstance", out createdNew);
+    if (createdNew) break;
+    mutex.Dispose();
+    Thread.Sleep(500);
+}
+
+if (!createdNew)
+{
+    MessageBox.Show("KeyStats is already running.", "KeyStats", ...);
+    Shutdown();
+    return;
+}
+_singleInstanceMutex = mutex;
+```
+
+### 重启对话框文案
+
+```
+en:
+  Language_RestartPromptTitle    = "Restart Required"
+  Language_RestartPromptMessage  = "KeyStats needs to restart to apply the new language. Restart now?"
+
+zh-Hans:
+  Language_RestartPromptTitle    = "需要重启"
+  Language_RestartPromptMessage  = "需要重启 KeyStats 才能切换语言。是否立即重启？"
+```
+
+## 翻译来源
+
+### macOS 版 key 映射规则
+
+macOS `Localizable.strings` 用点分式 + camelCase（`settings.title`、`notification.threshold.body.keys`）；WPF `.resx` 用下划线分隔的 PascalCase（`Settings_Title`、`Notification_Threshold_Body_Keys`）。
+
+规则：
+1. `.` → `_`
+2. 每段首字母大写
+3. `%@` → `{0}`，`%1$@` / `%2$@` → `{0}` / `{1}`
+4. 多个占位符的 key 加 `Format` 后缀
+
+例：
+
+```
+macOS:  "settings.mouseDistanceCalibration.success.message" = "10 cm ≈ %1$@, factor updated to %2$@.";
+WPF:    Settings_MouseDistanceCalibration_Success_MessageFormat = "10 cm ≈ {0}, factor updated to {1}."
+```
+
+### 复用 vs 新增
+
+**直接复用 macOS 翻译**（约 60-70%）：
+- 设置项标题（"通知设置" / "Notification Settings"）
+- 通用按钮（"OK" / "Cancel" / "Close" / "Retry"）
+- 错误/成功提示通用文案
+- 时间标签（"今日" / "Today"）
+
+**Windows 独有 key**：
+- 托盘相关：`Tray_OpenMainWindow`、`Tray_KeyHistory`、`Tray_Quit`
+- 启动错误：`Error_StartupFailedFormat`、`Error_AppAlreadyRunning`
+- Toast 通知（macOS 用 `UNUserNotificationCenter`，文案略不同）
+- 导入对话框：`Import_Mode_Merge`、`Import_Mode_Overwrite`、`Import_Mode_Cancel`
+- 重启提示：`Language_RestartPromptTitle/Message`
+- Language 设置卡片：`Settings_Language`、`Settings_LanguageDescription`、`Settings_Language_System`
+
+**macOS 有但 Windows 不需要**：
+- `permission.*`（macOS 辅助功能权限对话框，Windows 没有）
+- `menu.window`、`menu.closeWindow`（macOS 主菜单栏）
+- 部分 macOS 独有 setting key
+
+实施时一次性把所有中文抽到 `Strings.resx` / `Strings.zh-Hans.resx`，不分阶段；翻译质量靠对照 macOS 同概念词 + 自检 + 用户 review。
+
+## 迁移文件清单
+
+按 5 批次组织（可独立 PR 也可合并为一个大 PR）：
+
+### 第 1 批：基础设施（约 0.5 人天）
+
+| 文件 | 改动 |
+|---|---|
+| `Properties/Strings.resx` | 新建（英文，约 200 个 key） |
+| `Properties/Strings.zh-Hans.resx` | 新建（简体中文） |
+| `Helpers/LocalizationManager.cs` | 新建（约 60 行） |
+| `Models/AppSettings.cs` | 加 `LanguagePreference` 字段 |
+| `KeyStats.csproj` | 配 `.resx` 的 EmbeddedResource + 卫星程序集 culture |
+
+### 第 2 批：启动流程（约 0.25 人天）
+
+| 文件 | 改动要点 |
+|---|---|
+| `App.xaml.cs`（39 处中文） | mutex 错误、托盘菜单 5 个 item、导入/导出 toast、startup shortcut description、mutex 重试逻辑 |
+
+### 第 3 批：主要 UI 窗口（约 1.5 人天）
+
+| 文件 | 备注 |
+|---|---|
+| `Views/SettingsWindow.xaml` + `.cs`（14+1） | 同时新增 Language 卡片 |
+| `Views/StatsPopupWindow.xaml` + `.cs`（27+34） | 主弹窗，工作量最大 |
+| `Views/AppStatsWindow.xaml`（8） | |
+| `Views/KeyboardHeatmapWindow.xaml` + `.cs`（7+11） | |
+| `Views/KeyHistoryWindow.xaml`（9） | |
+| `Views/MouseCalibrationWindow.xaml` + `.cs`（15+9） | 鼠标校准向导，文案多 |
+| `Views/NotificationSettingsWindow.xaml`（11） | |
+| `Views/ImportModeDialog.xaml`（7） | |
+| `Views/ConfirmDialog.xaml` + `.cs`（4+3） | |
+
+### 第 4 批：自定义控件（约 0.5 人天）
+
+| 文件 | 备注 |
+|---|---|
+| `Views/Controls/KeyBreakdownControl.xaml`（1） | 空状态文案 |
+| `Views/Controls/StatsChartControl.xaml.cs`（15） | 图例/工具提示 |
+| `Views/Controls/KeyDistributionPieChartControl.xaml.cs`（4） | 图例 |
+
+### 第 5 批：ViewModel + Service（约 0.5 人天）
+
+| 文件 | 备注 |
+|---|---|
+| `ViewModels/StatsPopupViewModel.cs`（2） | 格式化字符串 |
+| `ViewModels/AppStatsViewModel.cs`（11） | 应用统计标签 |
+| `ViewModels/KeyHistoryViewModel.cs`（2） | 时间范围标签 |
+| `Services/StatsManager.cs`（11） | 异常 message 翻译；Console 日志改英文 |
+| `Services/NotificationService.cs`（3） | Toast 模板 |
+| `Services/InputMonitorService.cs`（6） | 核查后多为 Console 日志，改英文 |
+
+### 总计
+
+- **新建**：3 文件
+- **修改**：25 文件，约 358 处中文字符串迁移
+- **预估总工作量**：约 3-3.5 人天
+
+## 测试与验收
+
+### 自动化检查
+
+1. **编译期 key 校验**：`.resx` 自动生成静态属性，XAML 写错 key 直接编译失败
+2. **零中文残留扫描**：
+   ```bash
+   grep -rE '[一-鿿]' KeyStats.Windows/KeyStats/ \
+        --include='*.cs' --include='*.xaml' \
+        --exclude='*.Designer.cs'
+   ```
+   除注释、`Strings.zh-Hans.resx`、`KeyNameMapper` 等允许列表外应为 0
+3. **resx key 完整性脚本**（建议加 PowerShell/Python 检查）：
+   - 扫描 `Strings.resx` 所有 key
+   - 验证 `Strings.zh-Hans.resx` 同样存在（缺则警告但不阻断 — fallback 到英文不算 bug）
+   - 列出 only-in-zh-Hans 的 key（删除时漏删）
+
+### 手动测试矩阵
+
+#### 启动语言检测
+
+| 系统 UI 语言 | 期望 |
+|---|---|
+| `zh-CN` | 中文 UI |
+| `zh-Hans-CN` | 中文 UI |
+| `zh-TW` | 英文 UI（严格规则验证） |
+| `en-US` | 英文 UI |
+| `ja-JP` | 英文 UI（fallback 验证） |
+| `de-DE` | 英文 UI |
+
+测试方法：Windows Settings → Time & Language → 切换显示语言后重启应用；或 PowerShell `Set-WinUILanguageOverride`。
+
+#### 手动覆盖
+
+| 场景 | 期望 |
+|---|---|
+| 首次启动（无 settings.json） | 跟随系统检测 |
+| `languagePreference = "system"` | 跟随系统检测 |
+| `languagePreference = "zh-Hans"` | 强制中文（即使系统是英文） |
+| `languagePreference = "en"` | 强制英文（即使系统是中文） |
+| 老版本升级（缺该字段） | 默认 `"system"`，不破坏现有用户体验 |
+| 写错值 `"fr"` | fallback 到 `DetectFromSystem()`，不 crash |
+
+#### 切换流程
+
+1. 中文 UI 下打开 Settings → 选 English → 弹重启对话框（中文）→ 确认 → 退出 → 自动启动 → 全英文 UI ✅
+2. 同上但点取消 → ComboBox 选回原值，不重启，settings.json 不变 ✅
+3. 切换瞬间 mutex 冲突 → 新进程重试 1-2 次（500ms 间隔）→ 成功启动 ✅
+4. 切换前未保存的统计数据 → `OnExit` 的 `FlushPendingSave` 跑完 → 重启后数据完整 ✅
+
+#### UI 完整性
+
+每个窗口在中英文下各打开一次，检查窗口标题、所有按钮、Label/TextBlock、ToolTip、错误对话框、Toast 通知、空状态。9 个窗口：StatsPopup / Settings / NotificationSettings / MouseCalibration / AppStats / KeyboardHeatmap / KeyHistory / ImportModeDialog / ConfirmDialog。
+
+#### 边界
+
+- **长字符串溢出**：英文比中文长（"Mouse Distance Calibration" vs "距离校准"），检查 SettingsWindow 卡片不会撑破布局
+- **数字格式**：只动 `CurrentUICulture`，`CurrentCulture` 保持系统默认 → 数字 `1,234.56` 显示规则不变
+- **运行期系统语言变化**：app 不响应（要重启），符合预期
+- **Toast 历史**：旧 toast 不回退翻译，新发的用新语言
+
+### PR checklist
+
+- [ ] `Strings.resx` 和 `Strings.zh-Hans.resx` key 数量一致
+- [ ] 全文搜索 `[一-鿿]` 在 `*.cs` / `*.xaml` 文件里仅命中允许列表
+- [ ] 所有 9 个窗口在中英文下各跑一遍
+- [ ] 系统语言切换 4 个 case（zh-CN / zh-TW / en-US / ja-JP）启动测试
+- [ ] 升级测试：用旧版 settings.json 启动新版，确认无 crash 且默认跟随系统
+- [ ] 打包后从 `dist/` zip 启动验证（卫星程序集 `zh-Hans/KeyStats.resources.dll` 正确打包）
+
+### 验收 Demo 路径
+
+5 分钟可跑完：
+1. 系统语言为 `zh-CN`，启动 → 中文 UI
+2. 打开 Settings → 改 Language 为 English → 弹重启对话框（中文）→ 确认
+3. 重启后全英文 UI
+4. 改回 中文 → 弹重启对话框（英文）→ 确认 → 重启后中文
+
+## 已对齐的关键决策
+
+| 决策点 | 选项 |
+|---|---|
+| 是否提供手动语言切换 | 是（Settings 里加下拉，自动检测 + 手动覆盖） |
+| 系统语言判定规则 | 严格简体（`zh-CN`/`zh-Hans*`/`zh` → 中文；其它 → 英文） |
+| 切换语言生效方式 | 重启 app（弹确认对话框） |
+| 翻译技术方案 | `.resx` + 强类型 `Strings.Designer.cs` |
+| 中性 `.resx` 用哪种语言 | 英文（也是 fallback 兜底） |
+| `LanguagePreference` 持久化类型 | 字符串 `"system"` / `"zh-Hans"` / `"en"` |
+| `Strings.Designer.cs` 入库 | 入库（VS 默认行为） |
+| Settings 卡片位置 | 放最后 |
+| mutex 冲突处理 | 新进程启动时重试 1-2 次（500ms 间隔） |
+| mutex 失败提示 | 纯英文兜底（不走 `Strings.*`） |
+| Console 日志翻译 | 不翻译，借机统一改成英文（可选） |


### PR DESCRIPTION
Closes #108

## Summary
- Bilingual UI support (zh-Hans / English) for KeyStats Windows. 158 localization keys total. App auto-detects system language at startup (strict simplified Chinese rule: only `zh-CN`/`zh-Hans*`/`zh` → 中文; everything else → English) with manual override in Settings (restart to apply).
- Approach: `.resx` + hand-written strongly-typed `Strings` accessor (no Visual Studio Designer dependency). `LocalizationManager.ApplyAtStartup` runs first in `App.OnStartup` to set `Thread.CurrentUICulture`; mutex check has a 3-attempt 500ms-apart retry to handle the language-switch relaunch race window.
- 25 source files migrated (9 windows + 3 dialogs + 3 ViewModels + 3 custom controls + 3 services + `App.xaml.cs`). All ~358 hardcoded Chinese strings now flow through `Strings.<Key>` accessors. Console logs translated to English in the same pass.

## Changes
**New files**
- `Properties/Strings.resx` / `Strings.zh-Hans.resx` — 158 key bilingual resources
- `Properties/Strings.cs` — hand-written strongly-typed accessor class
- `Helpers/LocalizationManager.cs` — culture detection + application
- `docs/superpowers/specs/2026-04-29-windows-i18n-design.md` — design spec
- `docs/superpowers/plans/2026-04-29-windows-i18n.md` — implementation plan

**Key changes**
- `App.xaml.cs`: startup ordering adds `LocalizationManager.ApplyAtStartup`; mutex retry loop; tray menu / toasts / import-export dialogs all routed through Strings; catch block error message localized
- `Models/AppSettings.cs`: new `LanguagePreference` string field (default `"system"`, backward-compatible with old settings.json)
- `Views/SettingsWindow.xaml` + `.xaml.cs`: new Language card (System / 中文 / English); switching shows a restart confirmation dialog → `Process.Start` + `Application.Shutdown`
- `KeyStats.csproj`: explicit `<ManifestResourceName>` overrides ensure `.zh-Hans.resx` compiles to a satellite assembly correctly

**Resource strategy**
- Neutral `Strings.resx` = English (also serves as fallback; non-Chinese systems auto-resolve here)
- `Strings.zh-Hans.resx` = Simplified Chinese
- Physical key names (Backspace/Tab/Ctrl+Shift+A etc.), JSON field names, PostHog events, and unit suffixes (m/km/px) stay in English by design (not user-facing UI copy)
- Restart-on-switch design — no runtime live-switch complexity, per spec decision

## Test plan
(`dotnet` is unavailable on the macOS host; verify the items below on Windows.)

**Build / packaging**
- [ ] `dotnet build KeyStats/KeyStats.csproj -c Debug` succeeds
- [ ] After `dotnet build -c Release`, `bin/Release/net48/zh-Hans/KeyStats.resources.dll` satellite assembly exists
- [ ] `build.ps1 -Configuration Release` produces a zip that includes the satellite folder

**Startup language detection** (clear or set `%LOCALAPPDATA%\KeyStats\settings.json` to `languagePreference: "system"`)
- [ ] `zh-CN` system → Chinese UI
- [ ] `zh-Hans-CN` → Chinese UI
- [ ] `zh-TW` / `zh-HK` → English UI (strict simplified rule)
- [ ] `en-US` / `ja-JP` / `de-DE` → English UI

**Manual override**
- [ ] Settings → Language switched to English/中文 → restart prompt (in current language) → click OK → app exits and relaunches → new language applied
- [ ] Same, but click Cancel → ComboBox reverts, settings.json unchanged, no restart
- [ ] settings.json `languagePreference: "fr"` (invalid) → falls back to auto-detect, no crash
- [ ] Old settings.json (missing field) → defaults to `"system"`, runs normally

**UI completeness (each window, both languages)**
- [ ] StatsPopup (left-click tray icon)
- [ ] Settings (right-click tray → Settings)
- [ ] NotificationSettings, MouseCalibration, AppStats, KeyboardHeatmap, KeyHistory
- [ ] ImportModeDialog (Settings → Import), ConfirmDialog
- [ ] 5 tray menu items, Toast notifications, import/export error messages

**Edge cases**
- [ ] Launch two instances: the second shows the localized "already running" dialog, then exits
- [ ] During a language-switch relaunch, mutex collision is resolved by the new process's 1–2 retries
- [ ] Long English strings don't break SettingsWindow card layout
- [ ] Number formatting still follows system locale (`CurrentCulture` was deliberately not modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)