### PR TITLE
Fix app icon resolution

### DIFF
--- a/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
+++ b/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
@@ -17,7 +17,6 @@ namespace KeyStats.Helpers;
 public static class AppIconHelper
 {
     private const int MaxShortcutScanCount = 3000;
-    private const int MaxSteamSearchDirectories = 2000;
     private static readonly TimeSpan FailedIconCacheDuration = TimeSpan.FromSeconds(10);
     private static readonly Dictionary<string, IconCacheEntry> _iconCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly object _lock = new object();
@@ -428,36 +427,132 @@ public static class AppIconHelper
                     continue;
                 }
 
-                string commonPath;
-                try
+                foreach (var manifestPath in GetSteamAppManifestPaths(normalizedLibraryRoot))
                 {
-                    commonPath = Path.Combine(normalizedLibraryRoot, "steamapps", "common");
-                }
-                catch
-                {
-                    continue;
-                }
-
-                foreach (var exePath in FindExecutablesUnder(commonPath, MaxSteamSearchDirectories))
-                {
-                    var exeName = Path.GetFileName(exePath);
-                    if (string.IsNullOrWhiteSpace(exeName))
+                    var app = TryReadSteamAppManifest(normalizedLibraryRoot, manifestPath);
+                    if (app == null)
                     {
                         continue;
                     }
 
-                    if (!index.TryGetValue(exeName, out var paths))
+                    foreach (var exePath in FindExecutablesNearRoot(app.InstallPath))
                     {
-                        paths = new List<string>();
-                        index[exeName] = paths;
-                    }
+                        var exeName = Path.GetFileName(exePath);
+                        if (string.IsNullOrWhiteSpace(exeName))
+                        {
+                            continue;
+                        }
 
-                    paths.Add(exePath);
+                        if (!index.TryGetValue(exeName, out var paths))
+                        {
+                            paths = new List<string>();
+                            index[exeName] = paths;
+                        }
+
+                        paths.Add(exePath);
+                    }
                 }
             }
         }
 
         return index;
+    }
+
+    private static IEnumerable<string> GetSteamAppManifestPaths(string libraryRoot)
+    {
+        string steamAppsPath;
+        try
+        {
+            steamAppsPath = Path.Combine(libraryRoot, "steamapps");
+        }
+        catch
+        {
+            yield break;
+        }
+
+        if (!Directory.Exists(steamAppsPath))
+        {
+            yield break;
+        }
+
+        IEnumerable<string> manifests;
+        try
+        {
+            manifests = Directory.EnumerateFiles(steamAppsPath, "appmanifest_*.acf", SearchOption.TopDirectoryOnly).ToList();
+        }
+        catch
+        {
+            yield break;
+        }
+
+        foreach (var manifest in manifests)
+        {
+            yield return manifest;
+        }
+    }
+
+    private static SteamAppEntry? TryReadSteamAppManifest(string libraryRoot, string manifestPath)
+    {
+        Dictionary<string, string> manifestValues;
+        try
+        {
+            manifestValues = File.ReadLines(manifestPath)
+                .Select(TryParseKeyValueLine)
+                .Where(pair => pair.HasValue)
+                .ToDictionary(
+                    pair => pair!.Value.Key,
+                    pair => pair!.Value.Value,
+                    StringComparer.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return null;
+        }
+
+        if (!manifestValues.TryGetValue("installdir", out var installDir) ||
+            string.IsNullOrWhiteSpace(installDir))
+        {
+            return null;
+        }
+
+        string installPath;
+        try
+        {
+            installPath = Path.Combine(libraryRoot, "steamapps", "common", installDir);
+        }
+        catch
+        {
+            return null;
+        }
+
+        var normalizedInstallPath = NormalizeDirectoryPath(installPath);
+        if (normalizedInstallPath == null || !Directory.Exists(normalizedInstallPath))
+        {
+            return null;
+        }
+
+        return new SteamAppEntry(normalizedInstallPath);
+    }
+
+    private static KeyValuePair<string, string>? TryParseKeyValueLine(string line)
+    {
+        var trimmed = line.Trim();
+        if (!trimmed.StartsWith("\"", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var parts = trimmed.Split(new[] { '"' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Trim())
+            .Where(part => !string.IsNullOrWhiteSpace(part))
+            .ToList();
+
+        if (parts.Count < 2)
+        {
+            return null;
+        }
+
+        return new KeyValuePair<string, string>(parts[0], parts[1].Replace(@"\\", @"\"));
     }
 
     private static IEnumerable<string> GetSteamRoots()
@@ -535,51 +630,52 @@ public static class AppIconHelper
         }
     }
 
-    private static IEnumerable<string> FindExecutablesUnder(string root, int maxDirectories)
+    private static IEnumerable<string> FindExecutablesNearRoot(string root)
     {
         if (!Directory.Exists(root))
         {
             yield break;
         }
 
-        var visitedDirectories = 0;
-        var pending = new Queue<string>();
-        pending.Enqueue(root);
-
-        while (pending.Count > 0 && visitedDirectories < maxDirectories)
+        foreach (var exePath in EnumerateExecutables(root))
         {
-            var current = pending.Dequeue();
-            visitedDirectories++;
+            yield return exePath;
+        }
 
-            IEnumerable<string> files;
-            try
-            {
-                files = Directory.EnumerateFiles(current, "*.exe", SearchOption.TopDirectoryOnly);
-            }
-            catch
-            {
-                files = Enumerable.Empty<string>();
-            }
+        IEnumerable<string> firstLevelDirectories;
+        try
+        {
+            firstLevelDirectories = Directory.EnumerateDirectories(root).ToList();
+        }
+        catch
+        {
+            yield break;
+        }
 
-            foreach (var file in files)
+        foreach (var directory in firstLevelDirectories)
+        {
+            foreach (var exePath in EnumerateExecutables(directory))
             {
-                yield return file;
+                yield return exePath;
             }
+        }
+    }
 
-            IEnumerable<string> directories;
-            try
-            {
-                directories = Directory.EnumerateDirectories(current);
-            }
-            catch
-            {
-                continue;
-            }
+    private static IEnumerable<string> EnumerateExecutables(string root)
+    {
+        IEnumerable<string> files;
+        try
+        {
+            files = Directory.EnumerateFiles(root, "*.exe", SearchOption.TopDirectoryOnly).ToList();
+        }
+        catch
+        {
+            yield break;
+        }
 
-            foreach (var directory in directories)
-            {
-                pending.Enqueue(directory);
-            }
+        foreach (var file in files)
+        {
+            yield return file;
         }
     }
 
@@ -749,5 +845,15 @@ public static class AppIconHelper
         public string? TargetName { get; }
         public string? IconPath { get; }
         public string? TargetPath { get; }
+    }
+
+    private sealed class SteamAppEntry
+    {
+        public SteamAppEntry(string installPath)
+        {
+            InstallPath = installPath;
+        }
+
+        public string InstallPath { get; }
     }
 }

--- a/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
+++ b/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -17,7 +19,10 @@ namespace KeyStats.Helpers;
 public static class AppIconHelper
 {
     private const int MaxShortcutScanCount = 3000;
+    private const int SteamAppInfoIconSearchWindow = 16000;
     private static readonly TimeSpan FailedIconCacheDuration = TimeSpan.FromSeconds(10);
+    private static readonly Regex SteamExecutableRegex = new(@"[A-Za-z0-9_. \\/-]+\.exe", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex SteamIconHashRegex = new(@"\b[a-f0-9]{40}\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Dictionary<string, IconCacheEntry> _iconCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly object _lock = new object();
     private static readonly object _indexLock = new object();
@@ -419,6 +424,8 @@ public static class AppIconHelper
 
         foreach (var steamRoot in steamRoots)
         {
+            IndexSteamAppInfoIcons(index, steamRoot!);
+
             foreach (var libraryRoot in GetSteamLibraryFolders(steamRoot!).Prepend(steamRoot).Distinct(StringComparer.OrdinalIgnoreCase))
             {
                 var normalizedLibraryRoot = NormalizeDirectoryPath(libraryRoot);
@@ -443,19 +450,122 @@ public static class AppIconHelper
                             continue;
                         }
 
-                        if (!index.TryGetValue(exeName, out var paths))
-                        {
-                            paths = new List<string>();
-                            index[exeName] = paths;
-                        }
-
-                        paths.Add(exePath);
+                        AddIndexedPath(index, exeName, exePath);
                     }
                 }
             }
         }
 
         return index;
+    }
+
+    private static void IndexSteamAppInfoIcons(Dictionary<string, List<string>> index, string steamRoot)
+    {
+        string appInfoPath;
+        string iconDirectory;
+        try
+        {
+            appInfoPath = Path.Combine(steamRoot, "appcache", "appinfo.vdf");
+            iconDirectory = Path.Combine(steamRoot, "steam", "games");
+        }
+        catch
+        {
+            return;
+        }
+
+        if (!File.Exists(appInfoPath) || !Directory.Exists(iconDirectory))
+        {
+            return;
+        }
+
+        Dictionary<string, string> iconPaths;
+        try
+        {
+            iconPaths = Directory.EnumerateFiles(iconDirectory, "*.ico", SearchOption.TopDirectoryOnly)
+                .Select(path => new { Hash = Path.GetFileNameWithoutExtension(path), Path = path })
+                .Where(item => item.Hash.Length == 40)
+                .GroupBy(item => item.Hash, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.First().Path, StringComparer.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return;
+        }
+
+        if (iconPaths.Count == 0)
+        {
+            return;
+        }
+
+        string appInfoText;
+        try
+        {
+            appInfoText = Encoding.UTF8.GetString(File.ReadAllBytes(appInfoPath));
+        }
+        catch
+        {
+            return;
+        }
+
+        foreach (Match executableMatch in SteamExecutableRegex.Matches(appInfoText))
+        {
+            var executableName = NormalizeSteamExecutableName(executableMatch.Value);
+            if (string.IsNullOrWhiteSpace(executableName))
+            {
+                continue;
+            }
+
+            var iconPath = FindNearestSteamIconPath(appInfoText, executableMatch.Index, iconPaths);
+            if (iconPath == null)
+            {
+                continue;
+            }
+
+            AddIndexedPath(index, executableName!, iconPath);
+        }
+    }
+
+    private static string? NormalizeSteamExecutableName(string executableValue)
+    {
+        var normalized = executableValue.Trim().Replace('/', '\\');
+        var fileName = Path.GetFileName(normalized);
+        return string.IsNullOrWhiteSpace(fileName) ? null : fileName;
+    }
+
+    private static string? FindNearestSteamIconPath(string appInfoText, int executableIndex, Dictionary<string, string> iconPaths)
+    {
+        var startIndex = Math.Max(0, executableIndex - SteamAppInfoIconSearchWindow);
+        var length = executableIndex - startIndex;
+        if (length <= 0)
+        {
+            return null;
+        }
+
+        var precedingText = appInfoText.Substring(startIndex, length);
+        var matches = SteamIconHashRegex.Matches(precedingText);
+        for (var index = matches.Count - 1; index >= 0; index--)
+        {
+            if (iconPaths.TryGetValue(matches[index].Value, out var iconPath))
+            {
+                return iconPath;
+            }
+        }
+
+        return null;
+    }
+
+    private static void AddIndexedPath(Dictionary<string, List<string>> index, string executableName, string path)
+    {
+        if (!index.TryGetValue(executableName, out var paths))
+        {
+            paths = new List<string>();
+            index[executableName] = paths;
+        }
+
+        if (!paths.Contains(path, StringComparer.OrdinalIgnoreCase))
+        {
+            paths.Add(path);
+        }
     }
 
     private static IEnumerable<string> GetSteamAppManifestPaths(string libraryRoot)

--- a/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
+++ b/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -19,15 +18,18 @@ namespace KeyStats.Helpers;
 public static class AppIconHelper
 {
     private const int MaxShortcutScanCount = 3000;
+    private const int MaxSteamAppInfoBytes = 16 * 1024 * 1024;
     private const int SteamAppInfoIconSearchWindow = 16000;
+    private const int MaxSteamExecutableTokenBytes = 260;
     private static readonly TimeSpan FailedIconCacheDuration = TimeSpan.FromSeconds(10);
-    private static readonly Regex SteamExecutableRegex = new(@"[A-Za-z0-9_. \\/-]+\.exe", RegexOptions.IgnoreCase);
-    private static readonly Regex SteamIconHashRegex = new(@"\b[a-f0-9]{40}\b", RegexOptions.IgnoreCase);
+    private static readonly TimeSpan IndexRetryDelay = TimeSpan.FromSeconds(30);
     private static readonly Dictionary<string, IconCacheEntry> _iconCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly object _lock = new object();
     private static readonly object _indexLock = new object();
-    private static bool _shortcutIndexBuildStarted;
-    private static bool _steamIndexBuildStarted;
+    private static bool _shortcutIndexBuildInProgress;
+    private static bool _steamIndexBuildInProgress;
+    private static DateTime _shortcutIndexLastAttemptUtc = DateTime.MinValue;
+    private static DateTime _steamIndexLastAttemptUtc = DateTime.MinValue;
     private static List<ShortcutIconEntry>? _shortcutIndex;
     private static Dictionary<string, List<string>>? _steamExecutableIndex;
 
@@ -248,31 +250,44 @@ public static class AppIconHelper
     {
         lock (_indexLock)
         {
-            if (_shortcutIndexBuildStarted)
+            if (_shortcutIndex != null ||
+                _shortcutIndexBuildInProgress ||
+                DateTime.UtcNow - _shortcutIndexLastAttemptUtc < IndexRetryDelay)
             {
                 return;
             }
 
-            _shortcutIndexBuildStarted = true;
+            _shortcutIndexBuildInProgress = true;
+            _shortcutIndexLastAttemptUtc = DateTime.UtcNow;
         }
 
-        ThreadPool.QueueUserWorkItem(_ =>
+        var thread = new Thread(() =>
         {
-            List<ShortcutIconEntry> shortcutIndex;
             try
             {
-                shortcutIndex = BuildShortcutIndex().ToList();
+                var shortcutIndex = BuildShortcutIndex().ToList();
+                lock (_indexLock)
+                {
+                    _shortcutIndex = shortcutIndex;
+                    _shortcutIndexBuildInProgress = false;
+                }
             }
             catch
             {
-                shortcutIndex = new List<ShortcutIconEntry>();
+                lock (_indexLock)
+                {
+                    _shortcutIndex = null;
+                    _shortcutIndexBuildInProgress = false;
+                }
             }
+        })
+        {
+            IsBackground = true,
+            Name = "KeyStats Shortcut Icon Index"
+        };
 
-            lock (_indexLock)
-            {
-                _shortcutIndex = shortcutIndex;
-            }
-        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
     }
 
     private static IEnumerable<ShortcutIconEntry> BuildShortcutIndex()
@@ -386,29 +401,35 @@ public static class AppIconHelper
     {
         lock (_indexLock)
         {
-            if (_steamIndexBuildStarted)
+            if (_steamExecutableIndex != null ||
+                _steamIndexBuildInProgress ||
+                DateTime.UtcNow - _steamIndexLastAttemptUtc < IndexRetryDelay)
             {
                 return;
             }
 
-            _steamIndexBuildStarted = true;
+            _steamIndexBuildInProgress = true;
+            _steamIndexLastAttemptUtc = DateTime.UtcNow;
         }
 
         ThreadPool.QueueUserWorkItem(_ =>
         {
-            Dictionary<string, List<string>> steamIndex;
             try
             {
-                steamIndex = BuildSteamExecutableIndex();
+                var steamIndex = BuildSteamExecutableIndex();
+                lock (_indexLock)
+                {
+                    _steamExecutableIndex = steamIndex;
+                    _steamIndexBuildInProgress = false;
+                }
             }
             catch
             {
-                steamIndex = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-            }
-
-            lock (_indexLock)
-            {
-                _steamExecutableIndex = steamIndex;
+                lock (_indexLock)
+                {
+                    _steamExecutableIndex = null;
+                    _steamIndexBuildInProgress = false;
+                }
             }
         });
     }
@@ -497,17 +518,23 @@ public static class AppIconHelper
             return;
         }
 
-        string appInfoText;
+        var appInfoFile = new FileInfo(appInfoPath);
+        if (appInfoFile.Length > MaxSteamAppInfoBytes)
+        {
+            return;
+        }
+
+        byte[] appInfoBytes;
         try
         {
-            appInfoText = Encoding.UTF8.GetString(File.ReadAllBytes(appInfoPath));
+            appInfoBytes = File.ReadAllBytes(appInfoPath);
         }
         catch
         {
             return;
         }
 
-        foreach (Match executableMatch in SteamExecutableRegex.Matches(appInfoText))
+        foreach (var executableMatch in FindSteamExecutableMatches(appInfoBytes))
         {
             var executableName = NormalizeSteamExecutableName(executableMatch.Value);
             if (string.IsNullOrWhiteSpace(executableName))
@@ -515,13 +542,41 @@ public static class AppIconHelper
                 continue;
             }
 
-            var iconPath = FindNearestSteamIconPath(appInfoText, executableMatch.Index, iconPaths);
+            var iconPath = FindNearestSteamIconPath(appInfoBytes, executableMatch.Index, iconPaths);
             if (iconPath == null)
             {
                 continue;
             }
 
             AddIndexedPath(index, executableName!, iconPath);
+        }
+    }
+
+    private static IEnumerable<SteamExecutableMatch> FindSteamExecutableMatches(byte[] appInfoBytes)
+    {
+        for (var index = 0; index <= appInfoBytes.Length - 4; index++)
+        {
+            if (!IsAsciiDotExeAt(appInfoBytes, index))
+            {
+                continue;
+            }
+
+            var startIndex = index;
+            var minStartIndex = Math.Max(0, index - MaxSteamExecutableTokenBytes + 1);
+            while (startIndex > minStartIndex && IsSteamExecutablePathByte(appInfoBytes[startIndex - 1]))
+            {
+                startIndex--;
+            }
+
+            var length = index + 4 - startIndex;
+            if (length <= 4)
+            {
+                continue;
+            }
+
+            yield return new SteamExecutableMatch(
+                index,
+                Encoding.ASCII.GetString(appInfoBytes, startIndex, length));
         }
     }
 
@@ -532,26 +587,72 @@ public static class AppIconHelper
         return string.IsNullOrWhiteSpace(fileName) ? null : fileName;
     }
 
-    private static string? FindNearestSteamIconPath(string appInfoText, int executableIndex, Dictionary<string, string> iconPaths)
+    private static string? FindNearestSteamIconPath(byte[] appInfoBytes, int executableIndex, Dictionary<string, string> iconPaths)
     {
         var startIndex = Math.Max(0, executableIndex - SteamAppInfoIconSearchWindow);
-        var length = executableIndex - startIndex;
-        if (length <= 0)
+        for (var index = executableIndex - 40; index >= startIndex; index--)
         {
-            return null;
-        }
+            if (!IsSteamIconHashAt(appInfoBytes, index))
+            {
+                continue;
+            }
 
-        var precedingText = appInfoText.Substring(startIndex, length);
-        var matches = SteamIconHashRegex.Matches(precedingText);
-        for (var index = matches.Count - 1; index >= 0; index--)
-        {
-            if (iconPaths.TryGetValue(matches[index].Value, out var iconPath))
+            var hash = Encoding.ASCII.GetString(appInfoBytes, index, 40);
+            if (iconPaths.TryGetValue(hash, out var iconPath))
             {
                 return iconPath;
             }
         }
 
         return null;
+    }
+
+    private static bool IsAsciiDotExeAt(byte[] bytes, int index)
+    {
+        return bytes[index] == (byte)'.' &&
+               IsAsciiLower(bytes[index + 1], 'e') &&
+               IsAsciiLower(bytes[index + 2], 'x') &&
+               IsAsciiLower(bytes[index + 3], 'e');
+    }
+
+    private static bool IsAsciiLower(byte value, char expected)
+    {
+        return char.ToLowerInvariant((char)value) == expected;
+    }
+
+    private static bool IsSteamExecutablePathByte(byte value)
+    {
+        return value == (byte)' ' ||
+               value == (byte)'_' ||
+               value == (byte)'.' ||
+               value == (byte)'-' ||
+               value == (byte)'\\' ||
+               value == (byte)'/' ||
+               (value >= (byte)'0' && value <= (byte)'9') ||
+               (value >= (byte)'A' && value <= (byte)'Z') ||
+               (value >= (byte)'a' && value <= (byte)'z');
+    }
+
+    private static bool IsSteamIconHashAt(byte[] bytes, int index)
+    {
+        if (index < 0 || index + 40 > bytes.Length)
+        {
+            return false;
+        }
+
+        for (var offset = 0; offset < 40; offset++)
+        {
+            var value = bytes[index + offset];
+            var isHex = (value >= (byte)'0' && value <= (byte)'9') ||
+                        (value >= (byte)'a' && value <= (byte)'f') ||
+                        (value >= (byte)'A' && value <= (byte)'F');
+            if (!isHex)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static void AddIndexedPath(Dictionary<string, List<string>> index, string executableName, string path)
@@ -965,5 +1066,17 @@ public static class AppIconHelper
         }
 
         public string InstallPath { get; }
+    }
+
+    private readonly struct SteamExecutableMatch
+    {
+        public SteamExecutableMatch(int index, string value)
+        {
+            Index = index;
+            Value = value;
+        }
+
+        public int Index { get; }
+        public string Value { get; }
     }
 }

--- a/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
+++ b/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
@@ -21,8 +21,8 @@ public static class AppIconHelper
     private const int MaxShortcutScanCount = 3000;
     private const int SteamAppInfoIconSearchWindow = 16000;
     private static readonly TimeSpan FailedIconCacheDuration = TimeSpan.FromSeconds(10);
-    private static readonly Regex SteamExecutableRegex = new(@"[A-Za-z0-9_. \\/-]+\.exe", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static readonly Regex SteamIconHashRegex = new(@"\b[a-f0-9]{40}\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex SteamExecutableRegex = new(@"[A-Za-z0-9_. \\/-]+\.exe", RegexOptions.IgnoreCase);
+    private static readonly Regex SteamIconHashRegex = new(@"\b[a-f0-9]{40}\b", RegexOptions.IgnoreCase);
     private static readonly Dictionary<string, IconCacheEntry> _iconCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly object _lock = new object();
     private static readonly object _indexLock = new object();

--- a/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
+++ b/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
@@ -3,16 +3,22 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using Microsoft.Win32;
 
 namespace KeyStats.Helpers;
 
 public static class AppIconHelper
 {
-    private static readonly Dictionary<string, ImageSource?> _iconCache = new();
+    private const int MaxShortcutScanCount = 3000;
+    private const int MaxSteamSearchDirectories = 2000;
+    private static readonly TimeSpan FailedIconCacheDuration = TimeSpan.FromMinutes(2);
+    private static readonly Dictionary<string, IconCacheEntry> _iconCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly object _lock = new object();
 
     /// <summary>
@@ -21,80 +27,532 @@ public static class AppIconHelper
     /// </summary>
     public static ImageSource? GetAppIcon(string processName)
     {
+        return GetAppIcon(processName, null);
+    }
+
+    /// <summary>
+    /// Gets the icon for an application by its process name and optional display name.
+    /// Returns null if the icon cannot be retrieved.
+    /// </summary>
+    public static ImageSource? GetAppIcon(string processName, string? displayName)
+    {
         if (string.IsNullOrEmpty(processName) || processName == "Unknown")
         {
             return null;
         }
 
+        var cacheKey = string.IsNullOrWhiteSpace(displayName)
+            ? processName
+            : $"{processName}|{displayName!.Trim()}";
+
         lock (_lock)
         {
-            if (_iconCache.TryGetValue(processName, out var cachedIcon))
+            if (_iconCache.TryGetValue(cacheKey, out var cachedIcon) && cachedIcon.IsFresh)
             {
-                return cachedIcon;
+                return cachedIcon.Icon;
             }
         }
 
-        var icon = LoadAppIcon(processName);
+        var icon = LoadAppIcon(processName, displayName);
 
         lock (_lock)
         {
-            _iconCache[processName] = icon;
+            _iconCache[cacheKey] = new IconCacheEntry(icon, DateTime.UtcNow);
         }
 
         return icon;
     }
 
-    private static ImageSource? LoadAppIcon(string processName)
+    private static ImageSource? LoadAppIcon(string processName, string? displayName)
     {
         try
         {
-            // Try to find a running process with this name to get its executable path
-            var processes = Process.GetProcessesByName(processName);
-            if (processes.Length > 0)
+            foreach (var iconPath in GetIconCandidatePaths(processName, displayName))
             {
-                try
+                var icon = ExtractIconFromFile(iconPath);
+                if (icon != null)
                 {
-                    var exePath = processes[0].MainModule?.FileName;
-                    if (!string.IsNullOrEmpty(exePath) && File.Exists(exePath))
-                    {
-                        return ExtractIconFromFile(exePath!);
-                    }
-                }
-                catch
-                {
-                    // Access denied or process exited
-                }
-                finally
-                {
-                    foreach (var p in processes)
-                    {
-                        p.Dispose();
-                    }
-                }
-            }
-
-            // Fallback: try common locations
-            var possiblePaths = new[]
-            {
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), processName, $"{processName}.exe"),
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), processName, $"{processName}.exe"),
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), processName, $"{processName}.exe"),
-            };
-
-            foreach (var path in possiblePaths)
-            {
-                if (File.Exists(path))
-                {
-                    return ExtractIconFromFile(path);
+                    return icon;
                 }
             }
         }
         catch
         {
-            // Ignore errors
+            // Icon lookup is best-effort; never block opening stats UI.
         }
 
         return null;
+    }
+
+    private static IEnumerable<string> GetIconCandidatePaths(string processName, string? displayName)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var path in GetRunningProcessPaths(processName)
+                     .Concat(GetAppPathsRegistryEntries(processName))
+                     .Concat(GetKnownInstallPaths(processName))
+                     .Concat(GetShortcutIconPaths(processName, displayName))
+                     .Concat(GetSteamLibraryPaths(processName)))
+        {
+            var normalizedPath = NormalizeIconPath(path);
+            if (string.IsNullOrWhiteSpace(normalizedPath) || !File.Exists(normalizedPath))
+            {
+                continue;
+            }
+
+            if (seen.Add(normalizedPath!))
+            {
+                yield return normalizedPath!;
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetRunningProcessPaths(string processName)
+    {
+        Process[] processes;
+        try
+        {
+            processes = Process.GetProcessesByName(processName);
+        }
+        catch
+        {
+            yield break;
+        }
+
+        foreach (var process in processes)
+        {
+            using (process)
+            {
+                string? exePath = null;
+                try
+                {
+                    exePath = process.MainModule?.FileName;
+                }
+                catch
+                {
+                    // Protected/elevated processes may deny module access.
+                }
+
+                if (!string.IsNullOrWhiteSpace(exePath))
+                {
+                    yield return exePath!;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetAppPathsRegistryEntries(string processName)
+    {
+        var appPathNames = new[]
+        {
+            $"{processName}.exe",
+            processName
+        };
+
+        foreach (var hive in new[] { RegistryHive.CurrentUser, RegistryHive.LocalMachine })
+        {
+            foreach (var view in new[] { RegistryView.Registry64, RegistryView.Registry32 })
+            {
+                RegistryKey? baseKey = null;
+                try
+                {
+                    baseKey = RegistryKey.OpenBaseKey(hive, view);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                using (baseKey)
+                {
+                    foreach (var appPathName in appPathNames)
+                    {
+                        using var appPathKey = baseKey.OpenSubKey($@"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\{appPathName}");
+                        var path = appPathKey?.GetValue(null) as string;
+                        if (!string.IsNullOrWhiteSpace(path))
+                        {
+                            yield return path!;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetKnownInstallPaths(string processName)
+    {
+        var exeName = $"{processName}.exe";
+        var roots = new[]
+        {
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Programs"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "WindowsApps")
+        };
+
+        foreach (var root in roots.Where(r => !string.IsNullOrWhiteSpace(r)))
+        {
+            yield return Path.Combine(root, processName, exeName);
+            yield return Path.Combine(root, exeName);
+        }
+    }
+
+    private static IEnumerable<string> GetShortcutIconPaths(string processName, string? displayName)
+    {
+        foreach (var shortcutPath in EnumerateShortcutPaths())
+        {
+            var shortcutName = Path.GetFileNameWithoutExtension(shortcutPath);
+            if (!IsLikelyMatch(shortcutName, processName, displayName))
+            {
+                var targetName = Path.GetFileNameWithoutExtension(ResolveShortcutTargetPath(shortcutPath));
+                if (!IsLikelyMatch(targetName, processName, displayName))
+                {
+                    continue;
+                }
+            }
+
+            var iconPath = ResolveShortcutIconPath(shortcutPath);
+            if (!string.IsNullOrWhiteSpace(iconPath))
+            {
+                yield return iconPath!;
+            }
+
+            var targetPath = ResolveShortcutTargetPath(shortcutPath);
+            if (!string.IsNullOrWhiteSpace(targetPath))
+            {
+                yield return targetPath!;
+            }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateShortcutPaths()
+    {
+        var roots = new[]
+        {
+            Environment.GetFolderPath(Environment.SpecialFolder.StartMenu),
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonStartMenu),
+            Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory),
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonDesktopDirectory)
+        };
+
+        var count = 0;
+        foreach (var root in roots.Where(Directory.Exists).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            foreach (var shortcut in EnumerateShortcutPathsSafely(root))
+            {
+                if (++count > MaxShortcutScanCount)
+                {
+                    yield break;
+                }
+
+                yield return shortcut;
+            }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateShortcutPathsSafely(string root)
+    {
+        var pending = new Queue<string>();
+        pending.Enqueue(root);
+
+        while (pending.Count > 0)
+        {
+            var current = pending.Dequeue();
+
+            IEnumerable<string> shortcuts;
+            try
+            {
+                shortcuts = Directory.EnumerateFiles(current, "*.lnk", SearchOption.TopDirectoryOnly).ToList();
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var shortcut in shortcuts)
+            {
+                yield return shortcut;
+            }
+
+            IEnumerable<string> directories;
+            try
+            {
+                directories = Directory.EnumerateDirectories(current).ToList();
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var directory in directories)
+            {
+                pending.Enqueue(directory);
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetSteamLibraryPaths(string processName)
+    {
+        var steamRoots = GetSteamRoots()
+            .Select(NormalizeDirectoryPath)
+            .Where(path => path != null && Directory.Exists(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        foreach (var steamRoot in steamRoots)
+        {
+            foreach (var libraryRoot in GetSteamLibraryFolders(steamRoot!).Prepend(steamRoot).Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                var normalizedLibraryRoot = NormalizeDirectoryPath(libraryRoot);
+                if (normalizedLibraryRoot == null)
+                {
+                    continue;
+                }
+
+                string commonPath;
+                try
+                {
+                    commonPath = Path.Combine(normalizedLibraryRoot, "steamapps", "common");
+                }
+                catch
+                {
+                    continue;
+                }
+
+                foreach (var exePath in FindExecutableUnder(commonPath, $"{processName}.exe", MaxSteamSearchDirectories))
+                {
+                    yield return exePath;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetSteamRoots()
+    {
+        foreach (var hive in new[] { RegistryHive.CurrentUser, RegistryHive.LocalMachine })
+        {
+            foreach (var view in new[] { RegistryView.Registry64, RegistryView.Registry32 })
+            {
+                RegistryKey? baseKey = null;
+                try
+                {
+                    baseKey = RegistryKey.OpenBaseKey(hive, view);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                using (baseKey)
+                using (var steamKey = baseKey.OpenSubKey(@"SOFTWARE\Valve\Steam"))
+                {
+                    foreach (var valueName in new[] { "SteamPath", "InstallPath" })
+                    {
+                        var path = steamKey?.GetValue(valueName) as string;
+                        if (!string.IsNullOrWhiteSpace(path))
+                        {
+                            yield return path!;
+                        }
+                    }
+                }
+            }
+        }
+
+        yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam");
+        yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Steam");
+    }
+
+    private static IEnumerable<string> GetSteamLibraryFolders(string steamRoot)
+    {
+        var libraryFile = Path.Combine(steamRoot, "steamapps", "libraryfolders.vdf");
+        if (!File.Exists(libraryFile))
+        {
+            yield break;
+        }
+
+        string[] lines;
+        try
+        {
+            lines = File.ReadAllLines(libraryFile);
+        }
+        catch
+        {
+            yield break;
+        }
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+            if (!trimmed.StartsWith("\"path\"", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var parts = trimmed.Split(new[] { '"' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(part => part.Trim())
+                .Where(part => !string.IsNullOrWhiteSpace(part) &&
+                               !string.Equals(part, "path", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            var path = parts.LastOrDefault();
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                yield return path!.Replace(@"\\", @"\");
+            }
+        }
+    }
+
+    private static IEnumerable<string> FindExecutableUnder(string root, string exeName, int maxDirectories)
+    {
+        if (!Directory.Exists(root))
+        {
+            yield break;
+        }
+
+        var visitedDirectories = 0;
+        var pending = new Queue<string>();
+        pending.Enqueue(root);
+
+        while (pending.Count > 0 && visitedDirectories < maxDirectories)
+        {
+            var current = pending.Dequeue();
+            visitedDirectories++;
+
+            IEnumerable<string> files;
+            try
+            {
+                files = Directory.EnumerateFiles(current, exeName, SearchOption.TopDirectoryOnly);
+            }
+            catch
+            {
+                files = Enumerable.Empty<string>();
+            }
+
+            foreach (var file in files)
+            {
+                yield return file;
+            }
+
+            IEnumerable<string> directories;
+            try
+            {
+                directories = Directory.EnumerateDirectories(current);
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var directory in directories)
+            {
+                pending.Enqueue(directory);
+            }
+        }
+    }
+
+    private static string? ResolveShortcutTargetPath(string shortcutPath)
+    {
+        return ResolveShortcutProperty(shortcutPath, "TargetPath");
+    }
+
+    private static string? ResolveShortcutIconPath(string shortcutPath)
+    {
+        return ResolveShortcutProperty(shortcutPath, "IconLocation");
+    }
+
+    private static string? ResolveShortcutProperty(string shortcutPath, string propertyName)
+    {
+        object? shell = null;
+        object? shortcut = null;
+        try
+        {
+            var shellType = Type.GetTypeFromProgID("WScript.Shell");
+            if (shellType == null)
+            {
+                return null;
+            }
+
+            shell = Activator.CreateInstance(shellType);
+            shortcut = shellType.InvokeMember("CreateShortcut", System.Reflection.BindingFlags.InvokeMethod, null, shell, new object[] { shortcutPath });
+            return shortcut?.GetType().InvokeMember(propertyName, System.Reflection.BindingFlags.GetProperty, null, shortcut, null) as string;
+        }
+        catch
+        {
+            return null;
+        }
+        finally
+        {
+            if (shortcut != null && Marshal.IsComObject(shortcut))
+            {
+                Marshal.ReleaseComObject(shortcut);
+            }
+
+            if (shell != null && Marshal.IsComObject(shell))
+            {
+                Marshal.ReleaseComObject(shell);
+            }
+        }
+    }
+
+    private static string? NormalizeIconPath(string? rawPath)
+    {
+        if (string.IsNullOrWhiteSpace(rawPath))
+        {
+            return null;
+        }
+
+        var path = Environment.ExpandEnvironmentVariables(rawPath!.Trim().Trim('"'));
+        var commaIndex = path.LastIndexOf(',');
+        if (commaIndex > 1 && int.TryParse(path.Substring(commaIndex + 1).Trim(), out _))
+        {
+            path = path.Substring(0, commaIndex).Trim().Trim('"');
+        }
+
+        return string.IsNullOrWhiteSpace(path) ? null : path;
+    }
+
+    private static string? NormalizeDirectoryPath(string? rawPath)
+    {
+        var path = NormalizeIconPath(rawPath);
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return path!.IndexOfAny(Path.GetInvalidPathChars()) >= 0 ? null : path;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsLikelyMatch(string? candidate, string processName, string? displayName)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return false;
+        }
+
+        return IsLikelyMatch(candidate, processName) || IsLikelyMatch(candidate, displayName);
+    }
+
+    private static bool IsLikelyMatch(string? candidate, string? expected)
+    {
+        if (string.IsNullOrWhiteSpace(candidate) || string.IsNullOrWhiteSpace(expected))
+        {
+            return false;
+        }
+
+        var normalizedCandidate = candidate!;
+        var normalizedExpected = expected!;
+
+        return normalizedCandidate.IndexOf(normalizedExpected, StringComparison.OrdinalIgnoreCase) >= 0 ||
+               normalizedExpected.IndexOf(normalizedCandidate, StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private static ImageSource? ExtractIconFromFile(string filePath)
@@ -132,4 +590,17 @@ public static class AppIconHelper
 
     [System.Runtime.InteropServices.DllImport("gdi32.dll")]
     private static extern bool DeleteObject(IntPtr hObject);
+
+    private sealed class IconCacheEntry
+    {
+        public IconCacheEntry(ImageSource? icon, DateTime cachedAt)
+        {
+            Icon = icon;
+            CachedAt = cachedAt;
+        }
+
+        public ImageSource? Icon { get; }
+        public DateTime CachedAt { get; }
+        public bool IsFresh => Icon != null || DateTime.UtcNow - CachedAt < FailedIconCacheDuration;
+    }
 }

--- a/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
+++ b/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
@@ -79,9 +79,9 @@ public static class AppIconHelper
     {
         try
         {
-            foreach (var iconPath in GetIconCandidatePaths(processName, displayName))
+            foreach (var iconCandidate in GetIconCandidatePaths(processName, displayName))
             {
-                var icon = ExtractIconFromFile(iconPath);
+                var icon = ExtractIconFromFile(iconCandidate.Path, iconCandidate.IconIndex);
                 if (icon != null)
                 {
                     return icon;
@@ -96,7 +96,7 @@ public static class AppIconHelper
         return null;
     }
 
-    private static IEnumerable<string> GetIconCandidatePaths(string processName, string? displayName)
+    private static IEnumerable<IconCandidate> GetIconCandidatePaths(string processName, string? displayName)
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -106,15 +106,15 @@ public static class AppIconHelper
                      .Concat(GetIndexedShortcutIconPaths(processName, displayName))
                      .Concat(GetIndexedSteamLibraryPaths(processName)))
         {
-            var normalizedPath = NormalizeIconPath(path);
-            if (string.IsNullOrWhiteSpace(normalizedPath) || !File.Exists(normalizedPath))
+            var candidate = NormalizeIconCandidate(path);
+            if (candidate == null || !File.Exists(candidate.Path))
             {
                 continue;
             }
 
-            if (seen.Add(normalizedPath!))
+            if (seen.Add(candidate.CacheKey))
             {
-                yield return normalizedPath!;
+                yield return candidate;
             }
         }
     }
@@ -942,13 +942,27 @@ public static class AppIconHelper
         }
 
         var path = Environment.ExpandEnvironmentVariables(rawPath!.Trim().Trim('"'));
-        var commaIndex = path.LastIndexOf(',');
-        if (commaIndex > 1 && int.TryParse(path.Substring(commaIndex + 1).Trim(), out _))
+        return string.IsNullOrWhiteSpace(path) ? null : path;
+    }
+
+    private static IconCandidate? NormalizeIconCandidate(string? rawPath)
+    {
+        var path = NormalizeIconPath(rawPath);
+        if (string.IsNullOrWhiteSpace(path))
         {
-            path = path.Substring(0, commaIndex).Trim().Trim('"');
+            return null;
         }
 
-        return string.IsNullOrWhiteSpace(path) ? null : path;
+        var normalizedPath = path!;
+        int? iconIndex = null;
+        var commaIndex = normalizedPath.LastIndexOf(',');
+        if (commaIndex > 1 && int.TryParse(normalizedPath.Substring(commaIndex + 1).Trim(), out var parsedIconIndex))
+        {
+            iconIndex = parsedIconIndex;
+            normalizedPath = normalizedPath.Substring(0, commaIndex).Trim().Trim('"');
+        }
+
+        return string.IsNullOrWhiteSpace(normalizedPath) ? null : new IconCandidate(normalizedPath, iconIndex);
     }
 
     private static string? NormalizeDirectoryPath(string? rawPath)
@@ -993,8 +1007,17 @@ public static class AppIconHelper
                normalizedExpected.IndexOf(normalizedCandidate, StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
-    private static ImageSource? ExtractIconFromFile(string filePath)
+    private static ImageSource? ExtractIconFromFile(string filePath, int? iconIndex = null)
     {
+        if (iconIndex.HasValue)
+        {
+            var indexedIcon = ExtractIconFromFileByIndex(filePath, iconIndex.Value);
+            if (indexedIcon != null)
+            {
+                return indexedIcon;
+            }
+        }
+
         try
         {
             using var icon = Icon.ExtractAssociatedIcon(filePath);
@@ -1026,8 +1049,61 @@ public static class AppIconHelper
         }
     }
 
+    private static ImageSource? ExtractIconFromFileByIndex(string filePath, int iconIndex)
+    {
+        var largeIcons = new[] { IntPtr.Zero };
+        var smallIcons = new[] { IntPtr.Zero };
+
+        try
+        {
+            var extractedCount = ExtractIconEx(filePath, iconIndex, largeIcons, smallIcons, 1);
+            if (extractedCount == 0)
+            {
+                return null;
+            }
+
+            var iconHandle = largeIcons[0] != IntPtr.Zero ? largeIcons[0] : smallIcons[0];
+            if (iconHandle == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var imageSource = Imaging.CreateBitmapSourceFromHIcon(
+                iconHandle,
+                Int32Rect.Empty,
+                BitmapSizeOptions.FromEmptyOptions());
+
+            imageSource.Freeze();
+            return imageSource;
+        }
+        catch
+        {
+            return null;
+        }
+        finally
+        {
+            if (largeIcons[0] != IntPtr.Zero)
+            {
+                NativeInterop.DestroyIcon(largeIcons[0]);
+            }
+
+            if (smallIcons[0] != IntPtr.Zero && smallIcons[0] != largeIcons[0])
+            {
+                NativeInterop.DestroyIcon(smallIcons[0]);
+            }
+        }
+    }
+
     [System.Runtime.InteropServices.DllImport("gdi32.dll")]
     private static extern bool DeleteObject(IntPtr hObject);
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+    private static extern uint ExtractIconEx(
+        string szFileName,
+        int nIconIndex,
+        IntPtr[] phiconLarge,
+        IntPtr[] phiconSmall,
+        uint nIcons);
 
     private sealed class IconCacheEntry
     {
@@ -1056,6 +1132,19 @@ public static class AppIconHelper
         public string? TargetName { get; }
         public string? IconPath { get; }
         public string? TargetPath { get; }
+    }
+
+    private sealed class IconCandidate
+    {
+        public IconCandidate(string path, int? iconIndex)
+        {
+            Path = path;
+            IconIndex = iconIndex;
+        }
+
+        public string Path { get; }
+        public int? IconIndex { get; }
+        public string CacheKey => IconIndex.HasValue ? $"{Path},{IconIndex.Value}" : Path;
     }
 
     private sealed class SteamAppEntry

--- a/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
+++ b/KeyStats.Windows/KeyStats/Helpers/AppIconHelper.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -17,9 +18,14 @@ public static class AppIconHelper
 {
     private const int MaxShortcutScanCount = 3000;
     private const int MaxSteamSearchDirectories = 2000;
-    private static readonly TimeSpan FailedIconCacheDuration = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan FailedIconCacheDuration = TimeSpan.FromSeconds(10);
     private static readonly Dictionary<string, IconCacheEntry> _iconCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly object _lock = new object();
+    private static readonly object _indexLock = new object();
+    private static bool _shortcutIndexBuildStarted;
+    private static bool _steamIndexBuildStarted;
+    private static List<ShortcutIconEntry>? _shortcutIndex;
+    private static Dictionary<string, List<string>>? _steamExecutableIndex;
 
     /// <summary>
     /// Gets the icon for an application by its process name.
@@ -91,8 +97,8 @@ public static class AppIconHelper
         foreach (var path in GetRunningProcessPaths(processName)
                      .Concat(GetAppPathsRegistryEntries(processName))
                      .Concat(GetKnownInstallPaths(processName))
-                     .Concat(GetShortcutIconPaths(processName, displayName))
-                     .Concat(GetSteamLibraryPaths(processName)))
+                     .Concat(GetIndexedShortcutIconPaths(processName, displayName))
+                     .Concat(GetIndexedSteamLibraryPaths(processName)))
         {
             var normalizedPath = NormalizeIconPath(path);
             if (string.IsNullOrWhiteSpace(normalizedPath) || !File.Exists(normalizedPath))
@@ -199,31 +205,88 @@ public static class AppIconHelper
         }
     }
 
-    private static IEnumerable<string> GetShortcutIconPaths(string processName, string? displayName)
+    private static IEnumerable<string> GetIndexedShortcutIconPaths(string processName, string? displayName)
+    {
+        EnsureShortcutIndexBuildStarted();
+
+        List<ShortcutIconEntry>? shortcutIndex;
+        lock (_indexLock)
+        {
+            shortcutIndex = _shortcutIndex;
+        }
+
+        if (shortcutIndex == null)
+        {
+            yield break;
+        }
+
+        foreach (var shortcut in shortcutIndex)
+        {
+            if (!IsLikelyMatch(shortcut.ShortcutName, processName, displayName) &&
+                !IsLikelyMatch(shortcut.TargetName, processName, displayName))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(shortcut.IconPath))
+            {
+                yield return shortcut.IconPath!;
+            }
+
+            if (!string.IsNullOrWhiteSpace(shortcut.TargetPath))
+            {
+                yield return shortcut.TargetPath!;
+            }
+        }
+    }
+
+    private static void EnsureShortcutIndexBuildStarted()
+    {
+        lock (_indexLock)
+        {
+            if (_shortcutIndexBuildStarted)
+            {
+                return;
+            }
+
+            _shortcutIndexBuildStarted = true;
+        }
+
+        ThreadPool.QueueUserWorkItem(_ =>
+        {
+            List<ShortcutIconEntry> shortcutIndex;
+            try
+            {
+                shortcutIndex = BuildShortcutIndex().ToList();
+            }
+            catch
+            {
+                shortcutIndex = new List<ShortcutIconEntry>();
+            }
+
+            lock (_indexLock)
+            {
+                _shortcutIndex = shortcutIndex;
+            }
+        });
+    }
+
+    private static IEnumerable<ShortcutIconEntry> BuildShortcutIndex()
     {
         foreach (var shortcutPath in EnumerateShortcutPaths())
         {
             var shortcutName = Path.GetFileNameWithoutExtension(shortcutPath);
-            if (!IsLikelyMatch(shortcutName, processName, displayName))
-            {
-                var targetName = Path.GetFileNameWithoutExtension(ResolveShortcutTargetPath(shortcutPath));
-                if (!IsLikelyMatch(targetName, processName, displayName))
-                {
-                    continue;
-                }
-            }
-
-            var iconPath = ResolveShortcutIconPath(shortcutPath);
-            if (!string.IsNullOrWhiteSpace(iconPath))
-            {
-                yield return iconPath!;
-            }
-
             var targetPath = ResolveShortcutTargetPath(shortcutPath);
-            if (!string.IsNullOrWhiteSpace(targetPath))
+            var iconPath = ResolveShortcutIconPath(shortcutPath);
+            var targetName = Path.GetFileNameWithoutExtension(targetPath);
+
+            if (string.IsNullOrWhiteSpace(shortcutName) &&
+                string.IsNullOrWhiteSpace(targetName))
             {
-                yield return targetPath!;
+                continue;
             }
+
+            yield return new ShortcutIconEntry(shortcutName, targetName, iconPath, targetPath);
         }
     }
 
@@ -293,8 +356,62 @@ public static class AppIconHelper
         }
     }
 
-    private static IEnumerable<string> GetSteamLibraryPaths(string processName)
+    private static IEnumerable<string> GetIndexedSteamLibraryPaths(string processName)
     {
+        EnsureSteamIndexBuildStarted();
+
+        Dictionary<string, List<string>>? steamExecutableIndex;
+        lock (_indexLock)
+        {
+            steamExecutableIndex = _steamExecutableIndex;
+        }
+
+        if (steamExecutableIndex == null ||
+            !steamExecutableIndex.TryGetValue($"{processName}.exe", out var paths))
+        {
+            yield break;
+        }
+
+        foreach (var path in paths)
+        {
+            yield return path;
+        }
+    }
+
+    private static void EnsureSteamIndexBuildStarted()
+    {
+        lock (_indexLock)
+        {
+            if (_steamIndexBuildStarted)
+            {
+                return;
+            }
+
+            _steamIndexBuildStarted = true;
+        }
+
+        ThreadPool.QueueUserWorkItem(_ =>
+        {
+            Dictionary<string, List<string>> steamIndex;
+            try
+            {
+                steamIndex = BuildSteamExecutableIndex();
+            }
+            catch
+            {
+                steamIndex = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            lock (_indexLock)
+            {
+                _steamExecutableIndex = steamIndex;
+            }
+        });
+    }
+
+    private static Dictionary<string, List<string>> BuildSteamExecutableIndex()
+    {
+        var index = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         var steamRoots = GetSteamRoots()
             .Select(NormalizeDirectoryPath)
             .Where(path => path != null && Directory.Exists(path))
@@ -321,12 +438,26 @@ public static class AppIconHelper
                     continue;
                 }
 
-                foreach (var exePath in FindExecutableUnder(commonPath, $"{processName}.exe", MaxSteamSearchDirectories))
+                foreach (var exePath in FindExecutablesUnder(commonPath, MaxSteamSearchDirectories))
                 {
-                    yield return exePath;
+                    var exeName = Path.GetFileName(exePath);
+                    if (string.IsNullOrWhiteSpace(exeName))
+                    {
+                        continue;
+                    }
+
+                    if (!index.TryGetValue(exeName, out var paths))
+                    {
+                        paths = new List<string>();
+                        index[exeName] = paths;
+                    }
+
+                    paths.Add(exePath);
                 }
             }
         }
+
+        return index;
     }
 
     private static IEnumerable<string> GetSteamRoots()
@@ -404,7 +535,7 @@ public static class AppIconHelper
         }
     }
 
-    private static IEnumerable<string> FindExecutableUnder(string root, string exeName, int maxDirectories)
+    private static IEnumerable<string> FindExecutablesUnder(string root, int maxDirectories)
     {
         if (!Directory.Exists(root))
         {
@@ -423,7 +554,7 @@ public static class AppIconHelper
             IEnumerable<string> files;
             try
             {
-                files = Directory.EnumerateFiles(current, exeName, SearchOption.TopDirectoryOnly);
+                files = Directory.EnumerateFiles(current, "*.exe", SearchOption.TopDirectoryOnly);
             }
             catch
             {
@@ -602,5 +733,21 @@ public static class AppIconHelper
         public ImageSource? Icon { get; }
         public DateTime CachedAt { get; }
         public bool IsFresh => Icon != null || DateTime.UtcNow - CachedAt < FailedIconCacheDuration;
+    }
+
+    private sealed class ShortcutIconEntry
+    {
+        public ShortcutIconEntry(string? shortcutName, string? targetName, string? iconPath, string? targetPath)
+        {
+            ShortcutName = shortcutName;
+            TargetName = targetName;
+            IconPath = iconPath;
+            TargetPath = targetPath;
+        }
+
+        public string? ShortcutName { get; }
+        public string? TargetName { get; }
+        public string? IconPath { get; }
+        public string? TargetPath { get; }
     }
 }

--- a/KeyStats.Windows/KeyStats/ViewModels/AppStatsViewModel.cs
+++ b/KeyStats.Windows/KeyStats/ViewModels/AppStatsViewModel.cs
@@ -194,7 +194,7 @@ public class AppStatsViewModel : ViewModelBase
             {
                 AppName = app.AppName,
                 DisplayName = DisplayName(app),
-                Icon = AppIconHelper.GetAppIcon(app.AppName),
+                Icon = AppIconHelper.GetAppIcon(app.AppName, app.DisplayName),
                 KeysText = manager.FormatHistoryValue(StatsManager.HistoryMetric.KeyPresses, app.KeyPresses),
                 ClicksText = manager.FormatHistoryValue(StatsManager.HistoryMetric.Clicks, app.TotalClicks),
                 ScrollText = manager.FormatHistoryValue(StatsManager.HistoryMetric.ScrollDistance, app.ScrollDistance),

--- a/KeyStats.Windows/KeyStats/ViewModels/AppStatsViewModel.cs
+++ b/KeyStats.Windows/KeyStats/ViewModels/AppStatsViewModel.cs
@@ -189,12 +189,13 @@ public class AppStatsViewModel : ViewModelBase
             var keysRatio = app.KeyPresses / (double)maxKeys;
             var clicksRatio = app.TotalClicks / (double)maxClicks;
             var scrollRatio = app.ScrollDistance / maxScroll;
+            var displayName = DisplayName(app);
 
             AppStatsItems.Add(new AppStatsRowItem
             {
                 AppName = app.AppName,
-                DisplayName = DisplayName(app),
-                Icon = AppIconHelper.GetAppIcon(app.AppName, app.DisplayName),
+                DisplayName = displayName,
+                Icon = AppIconHelper.GetAppIcon(app.AppName, displayName),
                 KeysText = manager.FormatHistoryValue(StatsManager.HistoryMetric.KeyPresses, app.KeyPresses),
                 ClicksText = manager.FormatHistoryValue(StatsManager.HistoryMetric.Clicks, app.TotalClicks),
                 ScrollText = manager.FormatHistoryValue(StatsManager.HistoryMetric.ScrollDistance, app.ScrollDistance),

--- a/KeyStats.Windows/KeyStats/ViewModels/StatsPopupViewModel.cs
+++ b/KeyStats.Windows/KeyStats/ViewModels/StatsPopupViewModel.cs
@@ -313,7 +313,7 @@ public class StatsPopupViewModel : ViewModelBase
                 Name = app.DisplayName,
                 KeyPresses = manager.FormatNumber(app.KeyPresses),
                 Clicks = manager.FormatNumber(app.TotalClicks),
-                Icon = AppIconHelper.GetAppIcon(app.AppName)
+                Icon = AppIconHelper.GetAppIcon(app.AppName, app.DisplayName)
             });
         }
     }

--- a/KeyStats.Windows/KeyStats/Views/AppStatsWindow.xaml
+++ b/KeyStats.Windows/KeyStats/Views/AppStatsWindow.xaml
@@ -156,11 +156,13 @@
                                                     </Border.Width>
                                                     <TextBlock Text="{Binding KeysText}" FontSize="10" Foreground="White"
                                                                HorizontalAlignment="Right" Margin="0,0,4,0"
+                                                               VerticalAlignment="Center"
                                                                Visibility="{Binding KeysLabelInside, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                                 </Border>
                                                 <TextBlock Text="{Binding KeysText}" FontSize="10"
                                                            Foreground="{DynamicResource TextSecondaryBrush}"
                                                            HorizontalAlignment="Right" Margin="0,0,4,0"
+                                                           VerticalAlignment="Center"
                                                            Visibility="{Binding KeysLabelOutside, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                             </Grid>
                                         </Border>
@@ -181,11 +183,13 @@
                                                     </Border.Width>
                                                     <TextBlock Text="{Binding ClicksText}" FontSize="10" Foreground="White"
                                                                HorizontalAlignment="Right" Margin="0,0,4,0"
+                                                               VerticalAlignment="Center"
                                                                Visibility="{Binding ClicksLabelInside, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                                 </Border>
                                                 <TextBlock Text="{Binding ClicksText}" FontSize="10"
                                                            Foreground="{DynamicResource TextSecondaryBrush}"
                                                            HorizontalAlignment="Right" Margin="0,0,4,0"
+                                                           VerticalAlignment="Center"
                                                            Visibility="{Binding ClicksLabelOutside, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                             </Grid>
                                         </Border>
@@ -206,11 +210,13 @@
                                                     </Border.Width>
                                                     <TextBlock Text="{Binding ScrollText}" FontSize="10" Foreground="White"
                                                                HorizontalAlignment="Right" Margin="0,0,4,0"
+                                                               VerticalAlignment="Center"
                                                                Visibility="{Binding ScrollLabelInside, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                                 </Border>
                                                 <TextBlock Text="{Binding ScrollText}" FontSize="10"
                                                            Foreground="{DynamicResource TextSecondaryBrush}"
                                                            HorizontalAlignment="Right" Margin="0,0,4,0"
+                                                           VerticalAlignment="Center"
                                                            Visibility="{Binding ScrollLabelOutside, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                             </Grid>
                                         </Border>


### PR DESCRIPTION
Summary:
- improve app icon lookup across running processes, App Paths, common install paths, shortcuts, and Steam metadata
- move shortcut and Steam scans to one-time background indexes so popup creation stays responsive
- add Steam appinfo icon fallback for cached games such as RE7

Validation:
- dotnet build KeyStats\KeyStats.csproj -c Debug --no-restore -p:OutputPath=obj\codex-verify"