### PR TITLE
fix: harden helper accessibility startup recovery

### DIFF
--- a/KeyStats/AppDelegate.swift
+++ b/KeyStats/AppDelegate.swift
@@ -15,6 +15,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private let analyticsFirstOpenUTCKey = "analyticsFirstOpenUTC"
     private let analyticsInstallTrackedKey = "analyticsInstallTracked"
     private let helperAccessibilityGrantedKey = "helperAccessibilityGranted"
+    private let helperAccessibilityRecoverySuppressedKey = "helperAccessibilityRecoverySuppressed"
+    private let startupAccessibilityRecoveryDelays: [TimeInterval] = [1.0, 2.0, 4.0, 8.0, 12.0]
     private var wasPreviouslyInstalledAtLaunch = false
     private var didRestartHelperAfterStartupPermissionMiss = false
     private var shouldShowAccessibilityPromptOnLaunch: Bool {
@@ -119,31 +121,68 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func handleStartupAccessibilityDenied() {
-        let hadPreviousGrant = UserDefaults.standard.bool(forKey: helperAccessibilityGrantedKey) || wasPreviouslyInstalledAtLaunch
+        let defaults = UserDefaults.standard
+        let hadPreviousGrant = defaults.bool(forKey: helperAccessibilityGrantedKey)
+        let canUseInstallFallback = wasPreviouslyInstalledAtLaunch && !defaults.bool(forKey: helperAccessibilityRecoverySuppressedKey)
+        // These launch-recovery flags are read and written on the main queue.
         if hadPreviousGrant && !didRestartHelperAfterStartupPermissionMiss {
             didRestartHelperAfterStartupPermissionMiss = true
-            NSLog("[AppDelegate] helper reported accessibility=false after previous grant; restarting LaunchAgent before prompting")
-            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                HelperXPCClient.shared.disconnect()
-                do {
-                    try HelperSupervisor.shared.restartLaunchAgent()
-                    NSLog("[AppDelegate] helper LaunchAgent restarted after transient permission miss")
-                } catch {
-                    NSLog("[AppDelegate] helper LaunchAgent restart failed after transient permission miss: \(error)")
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-                    self?.connectHelperAndStart()
-                }
-            }
+            recoverStartupAccessibilityState(delays: startupAccessibilityRecoveryDelays)
+            return
+        }
+        if canUseInstallFallback && !didRestartHelperAfterStartupPermissionMiss {
+            didRestartHelperAfterStartupPermissionMiss = true
+            recoverStartupAccessibilityState(delays: startupAccessibilityRecoveryDelays)
             return
         }
 
+        defaults.set(false, forKey: helperAccessibilityGrantedKey)
+        defaults.set(true, forKey: helperAccessibilityRecoverySuppressedKey)
         if shouldShowAccessibilityPromptOnLaunch {
             showPermissionAlert()
         } else {
             print("开发模式启动：helper 未获辅助功能授权，跳过启动提示")
         }
         startPermissionPolling()
+    }
+
+    private func recoverStartupAccessibilityState(delays: [TimeInterval]) {
+        guard let delay = delays.first else {
+            restartHelperAfterStartupPermissionMiss()
+            return
+        }
+
+        let remainingDelays = Array(delays.dropFirst())
+        NSLog("[AppDelegate] helper reported accessibility=false; rechecking in \(delay)s before prompting")
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self = self else { return }
+            HelperXPCClient.shared.refreshState { [weak self] state in
+                DispatchQueue.main.async {
+                    guard let self = self else { return }
+                    if case .connected(_, let granted) = state, granted {
+                        self.handleAccessibilityPermissionGranted()
+                    } else {
+                        self.recoverStartupAccessibilityState(delays: remainingDelays)
+                    }
+                }
+            }
+        }
+    }
+
+    private func restartHelperAfterStartupPermissionMiss() {
+        NSLog("[AppDelegate] helper still reports accessibility=false after delayed rechecks; restarting LaunchAgent before prompting")
+        HelperXPCClient.shared.disconnect()
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            do {
+                try HelperSupervisor.shared.restartLaunchAgent()
+                NSLog("[AppDelegate] helper LaunchAgent restarted after transient permission miss")
+            } catch {
+                NSLog("[AppDelegate] helper LaunchAgent restart failed after transient permission miss: \(error)")
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                self?.connectHelperAndStart()
+            }
+        }
     }
 
     func requestAccessibilityPermission(analyticsSource: String) {
@@ -203,6 +242,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         permissionCheckTimer = nil
         didRestartHelperAfterStartupPermissionMiss = false
         UserDefaults.standard.set(true, forKey: helperAccessibilityGrantedKey)
+        UserDefaults.standard.set(false, forKey: helperAccessibilityRecoverySuppressedKey)
         HelperXPCClient.shared.startMonitoring { ok, code in
             NSLog("[AppDelegate] helper startMonitoring after grant ok=\(ok) code=\(code)")
         }

--- a/KeyStats/AppDelegate.swift
+++ b/KeyStats/AppDelegate.swift
@@ -14,6 +14,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private let launchAtLoginPromptedKey = "launchAtLoginPrompted"
     private let analyticsFirstOpenUTCKey = "analyticsFirstOpenUTC"
     private let analyticsInstallTrackedKey = "analyticsInstallTracked"
+    private let helperAccessibilityGrantedKey = "helperAccessibilityGranted"
+    private var wasPreviouslyInstalledAtLaunch = false
+    private var didRestartHelperAfterStartupPermissionMiss = false
     private var shouldShowAccessibilityPromptOnLaunch: Bool {
         #if DEBUG
         return false
@@ -26,6 +29,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // 必须在 trackInstallIfNeeded()/MenuBarController 任何 UserDefaults 写入之前采集，
         // 否则 fresh install 与升级用户在后续阶段已无差别。仅作为是否触发迁移提示的判据。
         let wasPreviouslyInstalled = UserDefaults.standard.bool(forKey: analyticsInstallTrackedKey)
+        wasPreviouslyInstalledAtLaunch = wasPreviouslyInstalled
 
         // 初始化 PostHog
         let config = PostHogConfig(apiKey: "phc_TYyyKIfGgL1CXZx7t9dY7igE3yNwNpjj9aqItSpNVLx", host: "https://us.i.posthog.com")
@@ -86,17 +90,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 switch state {
                 case .connected(_, let granted):
                     if granted {
+                        self.didRestartHelperAfterStartupPermissionMiss = false
+                        UserDefaults.standard.set(true, forKey: self.helperAccessibilityGrantedKey)
                         HelperXPCClient.shared.startMonitoring { ok, code in
                             NSLog("[AppDelegate] helper startMonitoring ok=\(ok) code=\(code)")
                         }
                         self.promptLaunchAtLoginIfNeeded()
                     } else {
-                        if self.shouldShowAccessibilityPromptOnLaunch {
-                            self.showPermissionAlert()
-                        } else {
-                            print("开发模式启动：helper 未获辅助功能授权，跳过启动提示")
-                        }
-                        self.startPermissionPolling()
+                        self.handleStartupAccessibilityDenied()
                     }
                 case .disconnected(let reason):
                     NSLog("[AppDelegate] helper disconnected: \(reason); retry in 5s")
@@ -115,6 +116,34 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return granted
         }
         return false
+    }
+
+    private func handleStartupAccessibilityDenied() {
+        let hadPreviousGrant = UserDefaults.standard.bool(forKey: helperAccessibilityGrantedKey) || wasPreviouslyInstalledAtLaunch
+        if hadPreviousGrant && !didRestartHelperAfterStartupPermissionMiss {
+            didRestartHelperAfterStartupPermissionMiss = true
+            NSLog("[AppDelegate] helper reported accessibility=false after previous grant; restarting LaunchAgent before prompting")
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                HelperXPCClient.shared.disconnect()
+                do {
+                    try HelperSupervisor.shared.restartLaunchAgent()
+                    NSLog("[AppDelegate] helper LaunchAgent restarted after transient permission miss")
+                } catch {
+                    NSLog("[AppDelegate] helper LaunchAgent restart failed after transient permission miss: \(error)")
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                    self?.connectHelperAndStart()
+                }
+            }
+            return
+        }
+
+        if shouldShowAccessibilityPromptOnLaunch {
+            showPermissionAlert()
+        } else {
+            print("开发模式启动：helper 未获辅助功能授权，跳过启动提示")
+        }
+        startPermissionPolling()
     }
 
     func requestAccessibilityPermission(analyticsSource: String) {
@@ -172,6 +201,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func handleAccessibilityPermissionGranted() {
         permissionCheckTimer?.invalidate()
         permissionCheckTimer = nil
+        didRestartHelperAfterStartupPermissionMiss = false
+        UserDefaults.standard.set(true, forKey: helperAccessibilityGrantedKey)
         HelperXPCClient.shared.startMonitoring { ok, code in
             NSLog("[AppDelegate] helper startMonitoring after grant ok=\(ok) code=\(code)")
         }

--- a/KeyStats/AppDelegate.swift
+++ b/KeyStats/AppDelegate.swift
@@ -16,9 +16,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private let analyticsInstallTrackedKey = "analyticsInstallTracked"
     private let helperAccessibilityGrantedKey = "helperAccessibilityGranted"
     private let helperAccessibilityRecoverySuppressedKey = "helperAccessibilityRecoverySuppressed"
-    private let startupAccessibilityRecoveryDelays: [TimeInterval] = [1.0, 2.0, 4.0, 8.0, 12.0]
+    private let startupAccessibilityRecoveryDelays: [TimeInterval] = [1.0, 2.0, 4.0, 6.0]
     private var wasPreviouslyInstalledAtLaunch = false
-    private var didRestartHelperAfterStartupPermissionMiss = false
+    private var didAttemptStartupAccessibilityRecovery = false
     private var shouldShowAccessibilityPromptOnLaunch: Bool {
         #if DEBUG
         return false
@@ -92,12 +92,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 switch state {
                 case .connected(_, let granted):
                     if granted {
-                        self.didRestartHelperAfterStartupPermissionMiss = false
-                        UserDefaults.standard.set(true, forKey: self.helperAccessibilityGrantedKey)
-                        HelperXPCClient.shared.startMonitoring { ok, code in
-                            NSLog("[AppDelegate] helper startMonitoring ok=\(ok) code=\(code)")
-                        }
-                        self.promptLaunchAtLoginIfNeeded()
+                        self.handleAccessibilityPermissionGranted()
                     } else {
                         self.handleStartupAccessibilityDenied()
                     }
@@ -125,13 +120,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let hadPreviousGrant = defaults.bool(forKey: helperAccessibilityGrantedKey)
         let canUseInstallFallback = wasPreviouslyInstalledAtLaunch && !defaults.bool(forKey: helperAccessibilityRecoverySuppressedKey)
         // These launch-recovery flags are read and written on the main queue.
-        if hadPreviousGrant && !didRestartHelperAfterStartupPermissionMiss {
-            didRestartHelperAfterStartupPermissionMiss = true
-            recoverStartupAccessibilityState(delays: startupAccessibilityRecoveryDelays)
-            return
-        }
-        if canUseInstallFallback && !didRestartHelperAfterStartupPermissionMiss {
-            didRestartHelperAfterStartupPermissionMiss = true
+        if (hadPreviousGrant || canUseInstallFallback) && !didAttemptStartupAccessibilityRecovery {
+            didAttemptStartupAccessibilityRecovery = true
             recoverStartupAccessibilityState(delays: startupAccessibilityRecoveryDelays)
             return
         }
@@ -159,10 +149,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             HelperXPCClient.shared.refreshState { [weak self] state in
                 DispatchQueue.main.async {
                     guard let self = self else { return }
-                    if case .connected(_, let granted) = state, granted {
+                    switch state {
+                    case .connected(_, true):
                         self.handleAccessibilityPermissionGranted()
-                    } else {
+                    case .connected(_, false):
                         self.recoverStartupAccessibilityState(delays: remainingDelays)
+                    default:
+                        self.restartHelperAfterStartupPermissionMiss()
                     }
                 }
             }
@@ -240,7 +233,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func handleAccessibilityPermissionGranted() {
         permissionCheckTimer?.invalidate()
         permissionCheckTimer = nil
-        didRestartHelperAfterStartupPermissionMiss = false
+        didAttemptStartupAccessibilityRecovery = false
         UserDefaults.standard.set(true, forKey: helperAccessibilityGrantedKey)
         UserDefaults.standard.set(false, forKey: helperAccessibilityRecoverySuppressedKey)
         HelperXPCClient.shared.startMonitoring { ok, code in

--- a/KeyStats/HelperSupervisor.swift
+++ b/KeyStats/HelperSupervisor.swift
@@ -52,6 +52,17 @@ final class HelperSupervisor {
         try ensureLaunchAgentRegistered(helperWasCopied: shouldCopy)
     }
 
+    func restartLaunchAgent() throws {
+        _ = runLaunchctl(["bootout", "gui/\(getuid())/\(HelperLocations.launchAgentLabel)"])
+        let res = runLaunchctl(["bootstrap", "gui/\(getuid())", HelperLocations.launchAgentPlistURL.path])
+        if res.status != 0 {
+            if isLaunchAgentLoaded() {
+                return
+            }
+            throw SupervisorError.launchctlFailed(res.status, res.stderr)
+        }
+    }
+
     // MARK: - LaunchAgent
 
     private func ensureLaunchAgentRegistered(helperWasCopied: Bool) throws {

--- a/KeyStats/HelperSupervisor.swift
+++ b/KeyStats/HelperSupervisor.swift
@@ -53,14 +53,7 @@ final class HelperSupervisor {
     }
 
     func restartLaunchAgent() throws {
-        _ = runLaunchctl(["bootout", "gui/\(getuid())/\(HelperLocations.launchAgentLabel)"])
-        let res = runLaunchctl(["bootstrap", "gui/\(getuid())", HelperLocations.launchAgentPlistURL.path])
-        if res.status != 0 {
-            if isLaunchAgentLoaded() {
-                return
-            }
-            throw SupervisorError.launchctlFailed(res.status, res.stderr)
-        }
+        try bootstrapLaunchAgent(restartExisting: true)
     }
 
     // MARK: - LaunchAgent

--- a/KeyStatsHelper/HelperXPCListener.swift
+++ b/KeyStatsHelper/HelperXPCListener.swift
@@ -118,9 +118,9 @@ final class HelperXPCListener: NSObject, NSXPCListenerDelegate, KeyStatsHelperPr
         }
         // AXIsProcessTrusted() 在 helper 进程刚被 launchd spawn 出来时
         // 偶尔会先返回 false（TCC 还没把当前 PID 跟 helper 的 cdhash 关联好）。
-        // 100ms / 400ms / 1000ms 后逐级重查，最多 ~1.5s 内若有任何一次返回
-        // true 就立刻返回，否则才报"未授权"。
-        Self.recheckAccessibility(tap: tap, delays: [0.1, 0.4, 1.0]) { granted in
+        // 使用指数退避重查，最多约 25s 内若有任何一次返回 true 就立刻返回，
+        // 否则才报"未授权"。
+        Self.recheckAccessibility(tap: tap, delays: [0.1, 0.3, 0.7, 1.5, 3.0, 6.0, 12.0]) { granted in
             reply(HelperLocations.interfaceVersion, granted)
         }
     }

--- a/KeyStatsHelper/HelperXPCListener.swift
+++ b/KeyStatsHelper/HelperXPCListener.swift
@@ -118,9 +118,9 @@ final class HelperXPCListener: NSObject, NSXPCListenerDelegate, KeyStatsHelperPr
         }
         // AXIsProcessTrusted() 在 helper 进程刚被 launchd spawn 出来时
         // 偶尔会先返回 false（TCC 还没把当前 PID 跟 helper 的 cdhash 关联好）。
-        // 使用指数退避重查，最多约 25s 内若有任何一次返回 true 就立刻返回，
-        // 否则才报"未授权"。
-        Self.recheckAccessibility(tap: tap, delays: [0.1, 0.3, 0.7, 1.5, 3.0, 6.0, 12.0]) { granted in
+        // 100ms / 400ms / 1000ms 后逐级重查，避免把通用 handshake
+        // 阻塞太久；更长的恢复窗口由主 app 的启动恢复流程串行处理。
+        Self.recheckAccessibility(tap: tap, delays: [0.1, 0.4, 1.0]) { granted in
             reply(HelperLocations.interfaceVersion, granted)
         }
     }


### PR DESCRIPTION
## Summary
- Extend helper Accessibility trust rechecks during launch to tolerate delayed TCC readiness.
- Restart the helper LaunchAgent once before prompting previously installed users to re-authorize.

## Changes
- Add startup false-negative handling in AppDelegate for previously granted or upgraded installs.
- Add a HelperSupervisor LaunchAgent restart helper.
- Increase helper-side AXIsProcessTrusted retry window with exponential backoff.

## Test Plan
- [x] xcodebuild -project KeyStats.xcodeproj -scheme KeyStats -configuration Debug build